### PR TITLE
Replace non letters from index name globally

### DIFF
--- a/src/resolvers/helpers/sort.js
+++ b/src/resolvers/helpers/sort.js
@@ -50,7 +50,7 @@ export function getSortTypeFromModel(typeName: string, model: MongooseModel): Gr
     let name = keys
       .join('__')
       .toUpperCase()
-      .replace(/[^_a-zA-Z0-9]/i, '__');
+      .replace(/[^_a-zA-Z0-9]/gi, '__');
     if (indexData[keys[0]] === 1) {
       name = `${name}_ASC`;
     } else if (indexData[keys[0]] === -1) {


### PR DESCRIPTION
Following example won't work otherwise

`Schema.index({ "team._id": 1, "reactions.userId": 1 });`