### PR TITLE
Copy resolvers args

### DIFF
--- a/src/__tests__/composeWithMongooseDiscriminators-test.js
+++ b/src/__tests__/composeWithMongooseDiscriminators-test.js
@@ -56,5 +56,21 @@ describe('composeWithMongooseDiscriminators ->', () => {
       expect(itc.isRequired('name')).toBe(true);
       expect(itc.isRequired('friends')).toBe(true);
     });
+
+    it('should be passed down record opts to resolvers', () => {
+      const typeComposer = composeWithMongooseDiscriminators(CharacterModel, {
+        resolvers: {
+          createOne: {
+            record: {
+              removeFields: ['friends'],
+              requiredFields: ['name'],
+            },
+          },
+        },
+      });
+      const createOneRecordArgTC = typeComposer.getResolver('createOne').getArgTC('record');
+      expect(createOneRecordArgTC.isRequired('name')).toBe(true);
+      expect(createOneRecordArgTC.hasField('friends')).toBe(false);
+    });
   });
 });

--- a/src/discriminators/__tests__/DiscriminatorTypeComposer-test.js
+++ b/src/discriminators/__tests__/DiscriminatorTypeComposer-test.js
@@ -1,6 +1,12 @@
 /* @flow */
 
-import { schemaComposer, graphql, TypeComposer, InterfaceTypeComposer } from 'graphql-compose';
+import {
+  SchemaComposer,
+  schemaComposer,
+  graphql,
+  TypeComposer,
+  InterfaceTypeComposer,
+} from 'graphql-compose';
 import { getCharacterModels } from '../__mocks__/characterModels';
 import { MovieModel } from '../__mocks__/movieModel';
 import { composeWithMongoose } from '../../composeWithMongoose';
@@ -497,6 +503,32 @@ describe('DiscriminatorTypeComposer', () => {
       });
 
       expect(tc.getFieldNames()).not.toEqual(expect.arrayContaining(['dob', 'starShips']));
+    });
+
+    it('should pass down baseTypeComposerResolverOptions', () => {
+      const personTC = composeWithMongooseDiscriminators(CharacterModel, {
+        schemaComposer: new SchemaComposer(),
+        resolvers: {
+          createOne: {
+            record: {
+              removeFields: ['friends'],
+              requiredFields: ['name'],
+            },
+          },
+        },
+      }).discriminator(PersonModel, {
+        resolvers: {
+          createOne: {
+            record: {
+              requiredFields: ['dob'],
+            },
+          },
+        },
+      });
+      const createOneRecordArgTC = personTC.getResolver('createOne').getArgTC('record');
+      expect(createOneRecordArgTC.isRequired('name')).toBe(true);
+      expect(createOneRecordArgTC.isRequired('dob')).toBe(true);
+      expect(createOneRecordArgTC.hasField('friends')).toBe(false);
     });
   });
 });

--- a/src/discriminators/__tests__/prepareChildResolvers-test.js
+++ b/src/discriminators/__tests__/prepareChildResolvers-test.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import { schemaComposer } from 'graphql-compose';
+import { getCharacterModels } from '../__mocks__/characterModels';
+import { composeWithMongooseDiscriminators } from '../../composeWithMongooseDiscriminators';
+
+const { CharacterModel, PersonModel } = getCharacterModels('type');
+
+describe('prepareChildResolvers()', () => {
+  describe('copyResolverArgTypes()', () => {
+    afterAll(() => {
+      schemaComposer.clear();
+    });
+    // Note childResolver Arg fields are copied from baseResolver
+    const baseDTC = composeWithMongooseDiscriminators(CharacterModel, {
+      resolvers: {
+        createOne: {
+          requiredFields: ['kind'],
+        },
+      },
+    });
+    const PersonTC = baseDTC.discriminator(PersonModel);
+
+    it('should copy base common ResolverArgTypes to child', () => {
+      expect(
+        baseDTC
+          .getResolver('createOne')
+          .getArgTC('record')
+          .getFieldType('kind')
+      ).toEqual(
+        PersonTC.getResolver('createOne')
+          .getArgTC('record')
+          .getFieldType('kind')
+      );
+    });
+  });
+});

--- a/src/discriminators/utils/__tests__/mergeCustomizationOptions-test.js
+++ b/src/discriminators/utils/__tests__/mergeCustomizationOptions-test.js
@@ -147,6 +147,12 @@ describe('mergeCustomizationOptions()', () => {
           removeFields: ['parent', 'child'],
         },
       },
+      updateById: {
+        record: {
+          removeFields: ['one', 'two'],
+          requiredFields: ['eight'],
+        },
+      },
       findMany: {
         limit: { defaultValue: 20 },
         // sort: false,
@@ -191,9 +197,9 @@ describe('mergeCustomizationOptions()', () => {
         },
       },
       updateById: {
-        input: {
-          removeFields: ['one', 'two', 'five'],
-          requiredFields: ['eight', 'two', 'five'],
+        record: {
+          removeFields: ['five'],
+          requiredFields: ['two', 'five'],
         },
       },
     },
@@ -228,13 +234,23 @@ describe('mergeCustomizationOptions()', () => {
       },
       findById: false,
       updateById: {
-        input: {
+        record: {
           removeFields: ['one', 'two', 'five'],
           requiredFields: ['eight', 'two', 'five'],
         },
       },
     },
   };
+
+  it('should return most base options if no child', () => {
+    expect((mergeCustomizationOptions(baseCustomOptions): any).resolvers).toEqual(
+      baseCustomOptions.resolvers
+    );
+  });
+
+  it('should return child if no base is found', () => {
+    expect(mergeCustomizationOptions({}, childCustomOptions)).toEqual(childCustomOptions);
+  });
 
   it('should merge customisation Options', () => {
     expect(mergeCustomizationOptions(baseCustomOptions, childCustomOptions)).toEqual(expected);


### PR DESCRIPTION
### Current Behavior
Before now, the fn `setBaseInputTypesOnChildInputTypes` copied the common fields in the inputTypeComposer of a given baseDTC to the `resolveArgFields`(i.e. `filter` or `record` arg Fields) of a child Composer. When you now pass `resolver specific` customizationOptions, those options are not reflected in childTC.

### Proposed solution
Copy resolverArg specific fieldTypes, This way, all the customizations applied to baseDTC resolverArgs are passed on.

### Changes
Apply Proposal and Rename fn `setBaseInputTypesOnChildInputTypes` to `copyResolverArgTypes`