### PR TITLE
Add TypeScript definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "main": "lib/index.js",
   "module": "mjs/index.mjs",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/graphql-compose/graphql-compose-mongoose.git"
@@ -39,6 +40,8 @@
     "mongoose": ">=4.0.0 || >=5.0.0"
   },
   "devDependencies": {
+    "@types/graphql": "^0.13.4",
+    "@types/mongoose": "^5.2.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",
@@ -66,7 +69,9 @@
     "prettier": "^1.14.2",
     "request": "^2.87.0",
     "rimraf": "^2.6.2",
-    "semantic-release": "^15.9.6"
+    "semantic-release": "^15.9.6",
+    "tslint": "^5.11.0",
+    "typescript": "^3.0.1"
   },
   "config": {
     "commitizen": {
@@ -86,11 +91,15 @@
     "build-mjs": "rimraf mjs && BABEL_ENV=mjs babel src --ignore __tests__,__mocks__ -d mjs && yarn build-mjs-rename && COPY_TO_FOLDER=mjs npm run build-flow",
     "build-mjs-rename": "find ./mjs -name \"*.js\" -exec bash -c 'mv \"$1\" \"${1%.js}\".mjs' - '{}' \\;",
     "build-flow": "echo `$1` && find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo ./${COPY_TO_FOLDER:-lib}$filepath | sed 's/.\\/src\\//\\//g'`.flow; done",
+    "build-ts": "find ./src -name '*.d.ts' -not -path '*/__*' | while read filepath; do cp $filepath `echo ./${COPY_TO_FOLDER:-lib}$filepath | sed 's/.\\/src\\//\\//g'`; done",
     "watch": "jest --watch",
     "coverage": "jest --coverage --maxWorkers 2",
-    "lint": "eslint --ext .js ./src",
+    "lint": "npm run eslint && npm run tslint",
+    "eslint": "eslint --ext .js ./src",
+    "tslint": "tslint -p . \"src/**/*.d.ts\"",
+    "tscheck": "tsc",
     "flow": "./node_modules/.bin/flow",
-    "test": "npm run coverage && npm run lint && npm run flow",
+    "test": "npm run coverage && npm run lint && npm run flow && npm run tscheck",
     "link": "yarn build && yarn link graphql-compose && yarn link graphql-compose-connection && yarn link mongoose && yarn link",
     "unlink": "yarn unlink graphql-compose && yarn unlink graphql-compose-connection && yarn unlink mongoose && yarn add graphql-compose graphql-compose-connection mongoose --dev",
     "semantic-release": "semantic-release"

--- a/src/composeWithMongoose.d.ts
+++ b/src/composeWithMongoose.d.ts
@@ -1,0 +1,121 @@
+import { InputTypeComposer, SchemaComposer, TypeComposer } from 'graphql-compose';
+import { Document, Model } from 'mongoose';
+import { ConnectionSortMapOpts } from './resolvers/connection';
+import {
+  FilterHelperArgsOpts, LimitHelperArgsOpts, RecordHelperArgsOpts, SortHelperArgsOpts,
+} from './resolvers/helpers';
+import { PaginationResolverOpts } from './resolvers/pagination';
+
+export type TypeConverterOpts = {
+  schemaComposer?: SchemaComposer<any>,
+  name?: string,
+  description?: string,
+  fields?: {
+    only?: string[],
+    remove?: string[],
+  },
+  inputType?: TypeConverterInputTypeOpts,
+  resolvers?: false | TypeConverterResolversOpts,
+};
+
+export type TypeConverterInputTypeOpts = {
+  name?: string,
+  description?: string,
+  fields?: {
+    only?: string[],
+    remove?: string[],
+    required?: string[],
+  },
+};
+
+export type TypeConverterResolversOpts = {
+  findById?: false,
+  findByIds?:
+    | false
+    | {
+      limit?: LimitHelperArgsOpts | false,
+      sort?: SortHelperArgsOpts | false,
+    },
+  findOne?:
+    | false
+    | {
+      filter?: FilterHelperArgsOpts | false,
+      sort?: SortHelperArgsOpts | false,
+      skip?: false,
+    },
+  findMany?:
+    | false
+    | {
+      filter?: FilterHelperArgsOpts | false,
+      sort?: SortHelperArgsOpts | false,
+      limit?: LimitHelperArgsOpts | false,
+      skip?: false,
+    },
+  updateById?:
+    | false
+    | {
+      record?: RecordHelperArgsOpts | false,
+    },
+  updateOne?:
+    | false
+    | {
+      input?: RecordHelperArgsOpts | false,
+      filter?: FilterHelperArgsOpts | false,
+      sort?: SortHelperArgsOpts | false,
+      skip?: false,
+    },
+  updateMany?:
+    | false
+    | {
+      record?: RecordHelperArgsOpts | false,
+      filter?: FilterHelperArgsOpts | false,
+      sort?: SortHelperArgsOpts | false,
+      limit?: LimitHelperArgsOpts | false,
+      skip?: false,
+    },
+  removeById?: false,
+  removeOne?:
+    | false
+    | {
+      filter?: FilterHelperArgsOpts | false,
+      sort?: SortHelperArgsOpts | false,
+    },
+  removeMany?:
+    | false
+    | {
+      filter?: FilterHelperArgsOpts | false,
+    },
+  createOne?:
+    | false
+    | {
+      record?: RecordHelperArgsOpts | false,
+    },
+  count?:
+    | false
+    | {
+      filter?: FilterHelperArgsOpts | false,
+    },
+  connection?: ConnectionSortMapOpts | false,
+  pagination?: PaginationResolverOpts | false,
+};
+
+export function composeWithMongoose(
+  model: Model<any>,
+  opts?: TypeConverterOpts): TypeComposer<any>;
+
+export function prepareFields(
+  tc: TypeComposer<any>,
+  opts: { only?: string[], remove?: string[] }): void;
+
+export function prepareInputFields(
+  inputTypeComposer: InputTypeComposer,
+  inputFieldsOpts: { only?: string[], remove?: string[], required?: string[] }): void;
+
+export function createInputType(
+  tc: TypeComposer<any>,
+  inputTypeOpts?: TypeConverterInputTypeOpts): void;
+
+export function createResolvers<TDocument extends Document>(
+  model: Model<TDocument>,
+  tc: TypeComposer<any>,
+  opts: TypeConverterResolversOpts): void;

--- a/src/composeWithMongooseDiscriminators.d.ts
+++ b/src/composeWithMongooseDiscriminators.d.ts
@@ -1,0 +1,6 @@
+import { TypeComposerClass } from 'graphql-compose';
+import { Model } from 'mongoose';
+
+export function composeWithMongooseDiscriminators(
+  baseModel: Model<any>,
+  opts?: { [opts: string]: any }): TypeComposerClass<any>;

--- a/src/fieldsConverter.d.ts
+++ b/src/fieldsConverter.d.ts
@@ -2,7 +2,7 @@ import { EnumTypeComposer, SchemaComposer, TypeComposer } from 'graphql-compose'
 import { GraphQLScalarType } from 'graphql-compose/lib/graphql';
 import { Model, Schema } from 'mongoose';
 
-// MongooseSchemaField<any> in the Flow version, MongooseSchemaField isn't there in mongoose's .d.ts
+// @ts-todo MongooseSchemaField<any> in the Flow version, MongooseSchemaField isn't there in mongoose's .d.ts
 type MongooseFieldT = any;
 
 type MongooseFieldMapT = { [fieldName: string]: MongooseFieldT };

--- a/src/fieldsConverter.d.ts
+++ b/src/fieldsConverter.d.ts
@@ -1,0 +1,74 @@
+import { EnumTypeComposer, SchemaComposer, TypeComposer } from 'graphql-compose';
+import { GraphQLScalarType } from 'graphql-compose/lib/graphql';
+import { Model, Schema } from 'mongoose';
+
+// MongooseSchemaField<any> in the Flow version, MongooseSchemaField isn't there in mongoose's .d.ts
+type MongooseFieldT = any;
+
+type MongooseFieldMapT = { [fieldName: string]: MongooseFieldT };
+type ComposeScalarType = string | GraphQLScalarType;
+
+type ComposeOutputType =
+  | TypeComposer<any> | ComposeScalarType | EnumTypeComposer
+  | [TypeComposer<any> | ComposeScalarType | EnumTypeComposer];
+
+export type MongoosePseudoModelT = {
+  schema: Schema,
+};
+
+export const ComplexTypes: {
+  ARRAY: 'ARRAY',
+  EMBEDDED: 'EMBEDDED',
+  DOCUMENT_ARRAY: 'DOCUMENT_ARRAY',
+  ENUM: 'ENUM',
+  REFERENCE: 'REFERENCE',
+  SCALAR: 'SCALAR',
+  MIXED: 'MIXED',
+};
+
+export function dotPathsToEmbedded(fields: MongooseFieldMapT): MongooseFieldMapT;
+
+export function getFieldsFromModel(model: Model<any> | MongoosePseudoModelT): MongooseFieldMapT;
+
+export function convertModelToGraphQL(
+  model: Model<any> | MongoosePseudoModelT,
+  typeName: string,
+  sc?: SchemaComposer<any>): TypeComposer<any>;
+
+export function convertSchemaToGraphQL(
+  schema: Schema,
+  typeName: string,
+  sc?: SchemaComposer<any>): TypeComposer<any>;
+
+export function convertFieldToGraphQL(
+  field: MongooseFieldT,
+  prefix: string | undefined,
+  schemaComposer: SchemaComposer<any>
+): ComposeOutputType;
+
+export function deriveComplexType(field: MongooseFieldT): keyof typeof ComplexTypes;
+
+export function scalarToGraphQL(field: MongooseFieldT): ComposeScalarType;
+
+export function arrayToGraphQL(
+  field: MongooseFieldT,
+  prefix: string | undefined,
+  schemaComposer: SchemaComposer<any>
+): ComposeOutputType;
+
+export function embeddedToGraphQL(
+  field: MongooseFieldT,
+  prefix: string | undefined,
+  schemaComposer: SchemaComposer<any>): TypeComposer<any>;
+
+export function enumToGraphQL(
+  field: MongooseFieldT,
+  prefix: string | undefined,
+  schemaComposer: SchemaComposer<any>): EnumTypeComposer;
+
+export function documentArrayToGraphQL(
+  field: MongooseFieldT,
+  prefix: string | undefined,
+  schemaComposer: SchemaComposer<any>): [TypeComposer<any>];
+
+export function referenceToGraphQL(field: MongooseFieldT): ComposeScalarType;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,10 @@
+import { composeWithMongoose } from './composeWithMongoose';
+import { composeWithMongooseDiscriminators } from './composeWithMongooseDiscriminators';
+import GraphQLMongoID from './types/mongoid';
+
+export default composeWithMongoose;
+
+export * from './fieldsConverter';
+// export * from './discriminators'; // untyped yet
+
+export { composeWithMongoose, composeWithMongooseDiscriminators, GraphQLMongoID };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,6 @@ import GraphQLMongoID from './types/mongoid';
 export default composeWithMongoose;
 
 export * from './fieldsConverter';
-// export * from './discriminators'; // untyped yet
+// @ts-todo export * from './discriminators'; // untyped yet
 
 export { composeWithMongoose, composeWithMongooseDiscriminators, GraphQLMongoID };

--- a/src/resolvers/connection.d.ts
+++ b/src/resolvers/connection.d.ts
@@ -1,0 +1,21 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+// import { ConnectionSortMapOpts } from 'graphql-compose-connection';
+import { Model } from 'mongoose';
+import { IndexT } from '../utils';
+
+// The ConnectionSortMapOpts is not available yet since graphql-compose-connection doesn't have types for now,
+// fallback to a simple object.
+export type ConnectionSortMapOpts = { [opt: string]: any };
+
+export default function connection(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: ConnectionSortMapOpts): Resolver<any, any> | undefined;
+
+export function prepareCursorQuery(
+  rawQuery: object,
+  cursorData: object,
+  indexKeys: string[],
+  indexData: IndexT,
+  nextOper: '$gt' | '$lt',
+  prevOper: '$lt' | '$gt'): void;

--- a/src/resolvers/connection.d.ts
+++ b/src/resolvers/connection.d.ts
@@ -3,8 +3,8 @@ import { Resolver, TypeComposer } from 'graphql-compose';
 import { Model } from 'mongoose';
 import { IndexT } from '../utils';
 
-// The ConnectionSortMapOpts is not available yet since graphql-compose-connection doesn't have types for now,
-// fallback to a simple object.
+// @ts-todo The ConnectionSortMapOpts is not available yet since graphql-compose-connection doesn't have types for now,
+//          fallback to a simple object.
 export type ConnectionSortMapOpts = { [opt: string]: any };
 
 export default function connection(

--- a/src/resolvers/count.d.ts
+++ b/src/resolvers/count.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function count(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/createOne.d.ts
+++ b/src/resolvers/createOne.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function createOne(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/findById.d.ts
+++ b/src/resolvers/findById.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function findById(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/findByIds.d.ts
+++ b/src/resolvers/findByIds.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function findByIds(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/findMany.d.ts
+++ b/src/resolvers/findMany.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function findMany(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/findOne.d.ts
+++ b/src/resolvers/findOne.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function findOne(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/helpers/filter.d.ts
+++ b/src/resolvers/helpers/filter.d.ts
@@ -1,0 +1,22 @@
+import { ComposeFieldConfigArgumentMap, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { ExtendedResolveParams } from '../index';
+import { FilterOperatorsOpts } from './filterOperators';
+
+export type FilterHelperArgsOpts = {
+  filterTypeName?: string,
+  isRequired?: boolean,
+  onlyIndexed?: boolean,
+  requiredFields?: string | string[],
+  operators?: FilterOperatorsOpts | false,
+  removeFields?: string | string[],
+};
+
+export function getFilterHelperArgOptsMap(): Partial<Record<keyof FilterHelperArgsOpts, string | string[]>>;
+
+export function filterHelperArgs(
+  typeComposer: TypeComposer<any>,
+  model: Model<any>,
+  opts?: FilterHelperArgsOpts): ComposeFieldConfigArgumentMap;
+
+export function filterHelper(resolveParams: ExtendedResolveParams): void;

--- a/src/resolvers/helpers/filterOperators.d.ts
+++ b/src/resolvers/helpers/filterOperators.d.ts
@@ -1,0 +1,21 @@
+import { InputTypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { ExtendedResolveParams } from '../index';
+import { FilterHelperArgsOpts } from './filter';
+
+export type FilterOperatorNames = 'gt' | 'gte' | 'lt' | 'lte' | 'ne' | 'in[]' | 'nin[]';
+
+export const OPERATORS_FIELDNAME: string;
+
+export type FilterOperatorsOpts = {
+  [fieldName: string]: FilterOperatorNames[] | false,
+};
+
+export function addFilterOperators(
+  itc: InputTypeComposer,
+  model: Model<any>,
+  opts: FilterHelperArgsOpts): void;
+
+export function processFilterOperators(
+  filter: object,
+  resolveParams: ExtendedResolveParams): void;

--- a/src/resolvers/helpers/index.d.ts
+++ b/src/resolvers/helpers/index.d.ts
@@ -1,0 +1,18 @@
+import { getFilterHelperArgOptsMap } from './filter';
+import { getLimitHelperArgsOptsMap } from './limit';
+import { getRecordHelperArgsOptsMap } from './record';
+
+export * from './filter';
+export * from './limit';
+export * from './projection';
+export * from './record';
+export * from './skip';
+export * from './sort';
+
+export const MergeAbleHelperArgsOpts: {
+  sort: string,
+  skip: string,
+  limit: ReturnType<typeof getLimitHelperArgsOptsMap>,
+  filter: ReturnType<typeof getFilterHelperArgOptsMap>,
+  record: ReturnType<typeof getRecordHelperArgsOptsMap>
+};

--- a/src/resolvers/helpers/limit.d.ts
+++ b/src/resolvers/helpers/limit.d.ts
@@ -1,0 +1,12 @@
+import { ComposeFieldConfigArgumentMap } from 'graphql-compose';
+import { ExtendedResolveParams } from '../index';
+
+export type LimitHelperArgsOpts = {
+  defaultValue?: number,
+};
+
+export function getLimitHelperArgsOptsMap(): Partial<Record<keyof LimitHelperArgsOpts, string | string[]>>;
+
+export function limitHelperArgs(opts?: LimitHelperArgsOpts): ComposeFieldConfigArgumentMap;
+
+export function limitHelper(resolveParams: ExtendedResolveParams): void;

--- a/src/resolvers/helpers/projection.d.ts
+++ b/src/resolvers/helpers/projection.d.ts
@@ -1,0 +1,3 @@
+import { ExtendedResolveParams } from '../index';
+
+export function projectionHelper(resolveParams: ExtendedResolveParams): void;

--- a/src/resolvers/helpers/record.d.ts
+++ b/src/resolvers/helpers/record.d.ts
@@ -1,0 +1,14 @@
+import { ComposeFieldConfigArgumentMap, TypeComposer } from 'graphql-compose';
+
+export type RecordHelperArgsOpts = {
+  recordTypeName?: string,
+  isRequired?: boolean,
+  removeFields?: string[],
+  requiredFields?: string[],
+};
+
+export function getRecordHelperArgsOptsMap(): Partial<Record<keyof RecordHelperArgsOpts, string | string[]>>;
+
+export function recordHelperArgs(
+  tc: TypeComposer<any>,
+  opts?: RecordHelperArgsOpts): ComposeFieldConfigArgumentMap;

--- a/src/resolvers/helpers/skip.d.ts
+++ b/src/resolvers/helpers/skip.d.ts
@@ -1,0 +1,6 @@
+import { ComposeFieldConfigArgumentMap } from 'graphql-compose';
+import { ExtendedResolveParams } from '../index';
+
+export function skipHelperArgs(): ComposeFieldConfigArgumentMap;
+
+export function skipHelper(resolveParams: ExtendedResolveParams): void;

--- a/src/resolvers/helpers/sort.d.ts
+++ b/src/resolvers/helpers/sort.d.ts
@@ -1,0 +1,20 @@
+import { ComposeFieldConfigArgumentMap, EnumTypeComposer, SchemaComposer, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { ExtendedResolveParams } from '../index';
+
+export type SortHelperArgsOpts = {
+  sortTypeName?: string,
+};
+
+export function sortHelperArgs(
+  typeComposer: TypeComposer<any>,
+  model: Model<any>,
+  opts?: SortHelperArgsOpts): ComposeFieldConfigArgumentMap;
+
+export function sortHelper(resolveParams: ExtendedResolveParams): void;
+
+export function getSortTypeFromModel(
+  typeName: string,
+  model: Model<any>,
+  schemaComposer: SchemaComposer<any>
+): EnumTypeComposer;

--- a/src/resolvers/index.d.ts
+++ b/src/resolvers/index.d.ts
@@ -1,0 +1,73 @@
+import { ResolveParams } from 'graphql-compose';
+import { DocumentQuery } from 'mongoose';
+import connection from './connection';
+import count from './count';
+
+import createOne from './createOne';
+
+import findById from './findById';
+import findByIds from './findByIds';
+import findMany from './findMany';
+import findOne from './findOne';
+
+import { FilterHelperArgsOpts, LimitHelperArgsOpts, RecordHelperArgsOpts, SortHelperArgsOpts } from './helpers';
+
+import pagination from './pagination';
+
+import removeById from './removeById';
+import removeMany from './removeMany';
+import removeOne from './removeOne';
+
+import updateById from './updateById';
+import updateMany from './updateMany';
+import updateOne from './updateOne';
+
+export type GenResolverOpts = {
+  filter?: FilterHelperArgsOpts,
+  sort?: SortHelperArgsOpts,
+  record?: RecordHelperArgsOpts,
+  limit?: LimitHelperArgsOpts,
+};
+
+export type ExtendedResolveParams = ResolveParams<any, any> & {
+  query: DocumentQuery<any, any>,
+  rawQuery: { [optName: string]: any },
+  beforeQuery?: (query: any, rp: ExtendedResolveParams) => Promise<any>,
+  beforeRecordMutate?: (record: any, rp: ExtendedResolveParams) => Promise<any>,
+};
+
+export {
+  findById,
+  findByIds,
+  findOne,
+  findMany,
+  updateById,
+  updateOne,
+  updateMany,
+  removeById,
+  removeOne,
+  removeMany,
+  createOne,
+  count,
+  pagination,
+  connection,
+};
+
+export function getAvailableNames(): string[];
+
+export const EMCResolvers: {
+  findById: 'findById',
+  findByIds: 'findByIds',
+  findOne: 'findOne',
+  findMany: 'findMany',
+  updateById: 'updateById',
+  updateOne: 'updateOne',
+  updateMany: 'updateMany',
+  removeById: 'removeById',
+  removeOne: 'removeOne',
+  removeMany: 'removeMany',
+  createOne: 'createOne',
+  count: 'count',
+  connection: 'connection',
+  pagination: 'pagination',
+};

--- a/src/resolvers/pagination.d.ts
+++ b/src/resolvers/pagination.d.ts
@@ -1,0 +1,11 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+
+export type PaginationResolverOpts = {
+  perPage?: number,
+};
+
+export default function pagination(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: PaginationResolverOpts): Resolver<any, any> | undefined;

--- a/src/resolvers/removeById.d.ts
+++ b/src/resolvers/removeById.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function removeById(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/removeMany.d.ts
+++ b/src/resolvers/removeMany.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function removeById(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/removeOne.d.ts
+++ b/src/resolvers/removeOne.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function removeOne(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/updateById.d.ts
+++ b/src/resolvers/updateById.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function updateById(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/updateMany.d.ts
+++ b/src/resolvers/updateMany.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function updateMany(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/updateOne.d.ts
+++ b/src/resolvers/updateOne.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function updateOne(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/types/mongoid.d.ts
+++ b/src/types/mongoid.d.ts
@@ -1,0 +1,5 @@
+import { GraphQLScalarType } from 'graphql-compose/lib/graphql';
+
+declare const GraphQLMongoID: GraphQLScalarType;
+
+export default GraphQLMongoID;

--- a/src/utils/getIndexesFromModel.d.ts
+++ b/src/utils/getIndexesFromModel.d.ts
@@ -1,0 +1,22 @@
+import { Model } from 'mongoose';
+
+export type getIndexesFromModelOpts = {
+  extractCompound?: boolean,
+  skipSpecificIndexes?: boolean,
+};
+
+export type IndexT = { [fieldName: string]: any };
+
+export function getIndexesFromModel(
+  mongooseModel: Model<any>,
+  opts?: getIndexesFromModelOpts): IndexT[];
+
+export function getUniqueIndexes(mongooseModel: Model<any>): IndexT[];
+
+export type ExtendByReversedIndexesOpts = {
+  reversedFirst?: boolean, // false by default
+};
+
+export function extendByReversedIndexes(indexes: IndexT[], opts?: ExtendByReversedIndexesOpts): IndexT[];
+
+export function getIndexedFieldNamesForGraphQL(model: Model<any>): string[];

--- a/src/utils/getIndexesFromModel.d.ts
+++ b/src/utils/getIndexesFromModel.d.ts
@@ -14,7 +14,7 @@ export function getIndexesFromModel(
 export function getUniqueIndexes(mongooseModel: Model<any>): IndexT[];
 
 export type ExtendByReversedIndexesOpts = {
-  reversedFirst?: boolean, // false by default
+  reversedFirst?: boolean,
 };
 
 export function extendByReversedIndexes(indexes: IndexT[], opts?: ExtendByReversedIndexesOpts): IndexT[];

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -1,0 +1,3 @@
+export { isObject, upperFirst } from 'graphql-compose';
+export { default as toMongoDottedObject } from './toMongoDottedObject';
+export * from './getIndexesFromModel';

--- a/src/utils/toMongoDottedObject.d.ts
+++ b/src/utils/toMongoDottedObject.d.ts
@@ -1,0 +1,4 @@
+export default function toMongoDottedObject(
+  obj: object,
+  target?: object,
+  path?: string[]): { [dottedPath: string]: any };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "lib": ["es2017", "esnext.asynciterable"]
+  },
+  "include": ["src/**/*.d.ts"],
+  "exclude": [
+    "./node_modules"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,18 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended"
+  ],
+  "jsRules": {},
+  "rules": {
+    "quotemark": [true, "single"],
+    "trailing-comma": [false],
+    "ordered-imports": false,
+    "member-ordering": [true, { "order": "fields-first" }],
+    "variable-name": false,
+    "interface-name": [true, "never-prefix"],
+    "no-reference-import": false,
+    "interface-over-type-literal": false
+  },
+  "rulesDirectory": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,40 @@
     into-stream "^3.1.0"
     lodash "^4.17.4"
 
+"@types/bson@*":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@types/bson/-/bson-1.0.11.tgz#c95ad69bb0b3f5c33b4bb6cc86d86cafb273335c"
+  dependencies:
+    "@types/node" "*"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/graphql@^0.13.4":
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.13.4.tgz#55ae9c29f0fd6b85ee536f5c72b4769d5c5e06b1"
+
+"@types/mongodb@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.1.3.tgz#73a2dba96cc10e9c9b0670a1a34a0caefe2c6c37"
+  dependencies:
+    "@types/bson" "*"
+    "@types/events" "*"
+    "@types/node" "*"
+
+"@types/mongoose@^5.2.4":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.2.4.tgz#ad66ba1d7bff5d854c35ee88a00cdda0df2acd70"
+  dependencies:
+    "@types/events" "*"
+    "@types/mongodb" "*"
+    "@types/node" "*"
+
+"@types/node@*":
+  version "10.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.7.tgz#960d9feb3ade2233bcc9843c918d740b4f78a7cf"
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1346,7 +1380,7 @@ buffer@^3.0.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1685,6 +1719,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
+commander@^2.12.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 commander@~2.8.1:
   version "2.8.1"
@@ -6220,6 +6258,12 @@ resolve@^1.2.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.3.2:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  dependencies:
+    path-parse "^1.0.5"
+
 resolve@^1.6.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
@@ -7019,6 +7063,33 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tslint@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.27.2"
+
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  dependencies:
+    tslib "^1.8.1"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -7038,6 +7109,10 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
Hello @nodkz,

After https://github.com/graphql-compose/graphql-compose/pull/82, I'm happy to propose definition files for graphql-compose-mongoose aswell.
Again, it's a "rapid" port from the flow version.

I've copied all the configuration from graphql-compose so you've got the same commands, structure and configuration files.

I've typed all of the API **except** the discriminators part. It's a bit complicated and I don't want to create too much files. Also, it's probably less used than the classic API.

For the part that has been typed, I've typed all exported symbols at module's level. That means not only what's just accessible on lib/index.d.ts, but all internal contents of the library. This is still useful when you have a semi-public API on submodules, or to maintain individual files by just copying the structure of the .js counterpart without wondering each time if it's exported by lib/index.d.ts.
I think it's the same in graphql-compose, but I don't really remember. Should we keep it like that?

I've also left a few `@ts-todo`-marked comments where porting the Flow version was not possible/difficult:

![image](https://user-images.githubusercontent.com/1343250/43915789-17f6353e-9c0c-11e8-8f58-d599d8496a92.png)

It's been tested in my latest project.

I think it may also interest @mernxl in https://github.com/graphql-compose/graphql-compose-mongoose/pull/107#issuecomment-405250067 even id I didn't typed his feature :smile:
I've made `composeWithMongooseDiscriminators` useable though, but the rest of this API is not available.
To answer his question about generated definitions, no, .d.ts generators are not really useable, runtime-based ones provide wrong or low-quality files, and Flow to TS converters are still experimental and will probably stay so.

-----
I want to thank you again for all the work you've done on these libraries. My team uses compose libraries on all new projects and we're really happy with them. That's hundreds of hours or LoCs saved.
We're using the mongoose plugin from the beginning but I've never taken the time to type it like the main one, and we were still using an auto-generated stub of very low quality. I would be happy to benefit from real typings!