### PR TITLE
Add createMany Resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ schemaComposer.Query.addFields({
 });
 
 schemaComposer.Mutation.addFields({
-  userCreate: UserTC.getResolver('createOne'),
+  userCreateOne: UserTC.getResolver('createOne'),
+  userCreateMany: UserTC.getResolver('createMany'),
   userUpdateById: UserTC.getResolver('updateById'),
   userUpdateOne: UserTC.getResolver('updateOne'),
   userUpdateMany: UserTC.getResolver('updateMany'),
@@ -374,17 +375,18 @@ fragment fullImageData on EmbeddedImage {
 ```
 
 ### Access and modify mongoose doc before save
-This library provides some amount of ready resolvers for fetch and update data which was mentioned above. And you can [create your own resolver](https://github.com/graphql-compose/graphql-compose) of course. However you can find that add some actions or light modifications of mongoose document directly before save at existing resolvers appears more simple than create new resolver. Some of resolvers accepts *before save hook* wich can be provided in *resolver params* as param named `beforeRecordMutate`. This hook allows to have access and modify mongoose document before save. The resolvers which supports this hook are:
+This library provides some amount of ready resolvers for fetch and update data which was mentioned above. And you can [create your own resolver](https://github.com/graphql-compose/graphql-compose) of course. However you can find that add some actions or light modifications of mongoose document directly before save at existing resolvers appears more simple than create new resolver. Some of resolvers accepts *before save hook* which can be provided in *resolver params* as param named `beforeRecordMutate`. This hook allows to have access and modify mongoose document before save. The resolvers which supports this hook are:
 
 * createOne
+* createMany
 * removeById
 * removeOne
 * updateById
 * updateOne
 
-The protype of before save hook:
+The prototype of before save hook:
 ```js
-(record: mixed, rp: ExtendedResolveParams) => Promise<*>,
+(doc: mixed, rp: ExtendedResolveParams) => Promise<*>,
 ```
 
 The typical implementation may be like this:
@@ -434,6 +436,7 @@ function adminAccess(resolvers) {
 // and wrap the resolvers
 schemaComposer.Mutation.addFields({
   createResource: ResourceTC.getResolver('createOne'),
+  createResources: ResourceTC.getResolver('createMany'),
   ...adminAccess({
     updateResource: ResourceTC.getResolver('updateById'),
     removeResource: ResourceTC.getResolver('removeById'),
@@ -521,6 +524,9 @@ export type typeConverterResolversOpts = {
   },
   createOne?: false | {
     record?: recordHelperArgsOpts | false,
+  },
+  createMany?: false | {
+    records?: recordHelperArgsOpts | false,
   },
   count?: false | {
     filter?: filterHelperArgsOpts | false,

--- a/src/__tests__/composeWithMongooseDiscriminators-test.js
+++ b/src/__tests__/composeWithMongooseDiscriminators-test.js
@@ -72,5 +72,21 @@ describe('composeWithMongooseDiscriminators ->', () => {
       expect(createOneRecordArgTC.isRequired('name')).toBe(true);
       expect(createOneRecordArgTC.hasField('friends')).toBe(false);
     });
+
+    it('should pass down records opts to createMany resolver', () => {
+      const typeComposer = composeWithMongooseDiscriminators(CharacterModel, {
+        resolvers: {
+          createMany: {
+            records: {
+              removeFields: ['friends'],
+              requiredFields: ['name'],
+            },
+          },
+        },
+      });
+      const createManyRecordsArgTC = typeComposer.getResolver('createMany').getArgTC('records');
+      expect(createManyRecordsArgTC.isRequired('name')).toBe(true);
+      expect(createManyRecordsArgTC.hasField('friends')).toBe(false);
+    });
   });
 });

--- a/src/composeWithMongoose.js
+++ b/src/composeWithMongoose.js
@@ -101,6 +101,11 @@ export type TypeConverterResolversOpts = {
     | {
         record?: RecordHelperArgsOpts | false,
       },
+  createMany?:
+    | false
+    | {
+        records?: RecordHelperArgsOpts | false,
+      },
   count?:
     | false
     | {

--- a/src/discriminators/__tests__/prepareChildResolvers-test.js
+++ b/src/discriminators/__tests__/prepareChildResolvers-test.js
@@ -1,12 +1,99 @@
 /* @flow */
 
-import { schemaComposer } from 'graphql-compose';
-import { getCharacterModels } from '../__mocks__/characterModels';
+import { schemaComposer, TypeComposer } from 'graphql-compose';
 import { composeWithMongooseDiscriminators } from '../../composeWithMongooseDiscriminators';
+import { getCharacterModels } from '../__mocks__/characterModels';
 
-const { CharacterModel, PersonModel } = getCharacterModels('type');
+const DKeyFieldName = 'type';
+const { CharacterModel, PersonModel } = getCharacterModels(DKeyFieldName);
+
+beforeAll(() => (CharacterModel: any).base.connect());
+afterAll(() => (CharacterModel: any).base.disconnect());
 
 describe('prepareChildResolvers()', () => {
+  describe('setQueryDKey()', () => {
+    let PersonTC: TypeComposer;
+
+    beforeAll(() => {
+      PersonTC = composeWithMongooseDiscriminators(CharacterModel).discriminator(PersonModel);
+    });
+
+    beforeEach(async () => {
+      await PersonModel.remove({});
+    });
+
+    it('should set DKey on createOne', async () => {
+      const res = await PersonTC.getResolver('createOne').resolve({
+        args: {
+          record: { name: 'Agent 007', dob: 124343 },
+        },
+      });
+
+      expect(res.record[DKeyFieldName]).toBe(PersonModel.modelName);
+    });
+
+    it('should set DKey on createMany', async () => {
+      const res = await PersonTC.getResolver('createMany').resolve({
+        args: {
+          records: [{ name: 'Agent 007', dob: 124343 }, { name: 'Agent 007', dob: 124343 }],
+        },
+      });
+
+      expect(res.records[0][DKeyFieldName]).toBe(PersonModel.modelName);
+      expect(res.records[1][DKeyFieldName]).toBe(PersonModel.modelName);
+    });
+  });
+
+  describe('hideDKey()', () => {
+    const resolversWithFilterArgs = [];
+    const resolversWithRecordArgs = [];
+    const resolversWithRecordsArgs = [];
+    const interestArgs = ['filter', 'record', 'records'];
+
+    beforeAll(() => {
+      const PersonTC = composeWithMongooseDiscriminators(CharacterModel).discriminator(PersonModel);
+
+      const resolvers = PersonTC.getResolvers();
+
+      resolvers.forEach(resolver => {
+        const argNames = resolver.getArgNames();
+
+        for (const argName of argNames) {
+          if (argName === interestArgs[0]) {
+            resolversWithFilterArgs.push(resolver);
+          }
+          if (argName === interestArgs[1]) {
+            resolversWithRecordArgs.push(resolver);
+          }
+          if (argName === interestArgs[2]) {
+            resolversWithRecordsArgs.push(resolver);
+          }
+        }
+      });
+    });
+
+    it('should hide DKey field on filter args', () => {
+      for (const resolver of resolversWithFilterArgs) {
+        expect(interestArgs[0]).toEqual('filter');
+        expect(resolver.getArgTC(interestArgs[0]).hasField(DKeyFieldName)).toBeFalsy();
+      }
+    });
+
+    it('should hide DKey field on record args', () => {
+      for (const resolver of resolversWithRecordArgs) {
+        expect(interestArgs[1]).toEqual('record');
+        expect(resolver.getArgTC(interestArgs[1]).hasField(DKeyFieldName)).toBeFalsy();
+      }
+    });
+
+    it('should hide DKey field on records args', () => {
+      for (const resolver of resolversWithRecordsArgs) {
+        expect(interestArgs[2]).toEqual('records');
+        expect(resolver.getArgTC(interestArgs[2]).hasField(DKeyFieldName)).toBeFalsy();
+      }
+    });
+  });
+
   describe('copyResolverArgTypes()', () => {
     afterAll(() => {
       schemaComposer.clear();

--- a/src/discriminators/prepareChildResolvers.js
+++ b/src/discriminators/prepareChildResolvers.js
@@ -22,7 +22,12 @@ function setQueryDKey<TSource, TContext>(
       resolve.args = resolve.args ? resolve.args : {};
       resolve.projection = resolve.projection ? resolve.projection : {};
 
-      if (fromField) {
+      if (fromField === 'records') {
+        resolve.args[fromField] = resolve.args[fromField] || [];
+        for (const record of resolve.args[fromField]) {
+          record[DKey] = DName;
+        }
+      } else if (fromField) {
         resolve.args[fromField] = resolve.args[fromField] ? resolve.args[fromField] : {};
         resolve.args[fromField][DKey] = DName;
       } else {
@@ -142,6 +147,12 @@ export function prepareChildResolvers<TContext>(
           hideDKey(resolver, childTC, baseDTC.getDKey(), 'record');
           break;
 
+        case EMCResolvers.createMany:
+          setQueryDKey(resolver, childTC, baseDTC.getDKey(), 'records');
+
+          hideDKey(resolver, childTC, baseDTC.getDKey(), 'records');
+          break;
+
         case EMCResolvers.updateById:
           hideDKey(resolver, childTC, baseDTC.getDKey(), 'record');
           break;
@@ -169,8 +180,12 @@ export function prepareChildResolvers<TContext>(
         default:
       }
 
-      copyResolverArgTypes(resolver, baseDTC, ['filter', 'record']);
-      reorderFieldsRecordFilter(resolver, baseDTC, opts.reorderFields, ['filter', 'record']);
+      copyResolverArgTypes(resolver, baseDTC, ['filter', 'record', 'records']);
+      reorderFieldsRecordFilter(resolver, baseDTC, opts.reorderFields, [
+        'filter',
+        'record',
+        'records',
+      ]);
     }
   }
 }

--- a/src/discriminators/utils/__tests__/mergeTypeConverterResolverOpts-test.js
+++ b/src/discriminators/utils/__tests__/mergeTypeConverterResolverOpts-test.js
@@ -23,6 +23,16 @@ const baseConverterResolverOpts: TypeConverterResolversOpts = {
     },
   },
   findById: false,
+  createOne: {
+    record: {
+      removeFields: ['one'],
+    },
+  },
+  createMany: {
+    records: {
+      removeFields: ['one', 'two'],
+    },
+  },
 };
 
 const childConverterResolverOpts: TypeConverterResolversOpts = {
@@ -37,6 +47,16 @@ const childConverterResolverOpts: TypeConverterResolversOpts = {
         two: ['gt', 'gte', 'lt', 'lte', 'ne'],
         three: ['gte', 'lt'],
       },
+    },
+  },
+  createOne: {
+    record: {
+      removeFields: ['one'],
+    },
+  },
+  createMany: {
+    records: {
+      requiredFields: ['two'],
     },
   },
 };
@@ -57,6 +77,17 @@ const expectedConverterResolverOpts: TypeConverterResolversOpts = {
     },
   },
   findById: false,
+  createOne: {
+    record: {
+      removeFields: ['one'],
+    },
+  },
+  createMany: {
+    records: {
+      removeFields: ['one', 'two'],
+      requiredFields: ['two'],
+    },
+  },
 };
 
 describe('mergeTypeConverterResolverOpts()', () => {

--- a/src/resolvers/__tests__/__snapshots__/createMany-test.js.snap
+++ b/src/resolvers/__tests__/__snapshots__/createMany-test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createMany() -> Resolver.resolve():Promise should rejected with Error if args.records is array with empty items 1`] = `[Error: User.createMany resolver requires args.records to contain non-empty records, with at least one value]`;
+
+exports[`createMany() -> Resolver.resolve():Promise should rejected with Error if args.records is empty 1`] = `[Error: User.createMany resolver requires args.records to be an Array and must contain at least one record]`;
+
+exports[`createMany() -> Resolver.resolve():Promise should rejected with Error if args.records is empty array 1`] = `[Error: User.createMany resolver requires args.records to be an Array and must contain at least one record]`;
+
+exports[`createMany() -> Resolver.resolve():Promise should rejected with Error if args.records is not array 1`] = `[Error: User.createMany resolver requires args.records to be an Array and must contain at least one record]`;

--- a/src/resolvers/__tests__/createMany-test.js
+++ b/src/resolvers/__tests__/createMany-test.js
@@ -1,0 +1,220 @@
+/* @flow */
+/* eslint-disable no-param-reassign,func-names */
+
+import { Resolver, schemaComposer, TypeComposer } from 'graphql-compose';
+import { GraphQLInt, GraphQLList, GraphQLNonNull } from 'graphql-compose/lib/graphql';
+import { mongoose } from '../../__mocks__/mongooseCommon';
+import { UserModel } from '../../__mocks__/userModel';
+import { convertModelToGraphQL } from '../../fieldsConverter';
+import GraphQLMongoID from '../../types/mongoid';
+import createMany from '../createMany';
+
+beforeAll(() => UserModel.base.connect());
+afterAll(() => UserModel.base.disconnect());
+
+describe('createMany() ->', () => {
+  let UserTC;
+
+  beforeEach(() => {
+    schemaComposer.clear();
+    UserTC = convertModelToGraphQL(UserModel, 'User', schemaComposer);
+    UserTC.setRecordIdFn(source => (source ? `${source._id}` : ''));
+  });
+
+  beforeEach(async () => {
+    await UserModel.remove({});
+  });
+
+  it('should return Resolver object', () => {
+    const resolver = createMany(UserModel, UserTC);
+    expect(resolver).toBeInstanceOf(Resolver);
+  });
+
+  describe('Resolver.args', () => {
+    it('should have required `records` arg', () => {
+      const resolver = createMany(UserModel, UserTC);
+      const argConfig: any = resolver.getArgConfig('records');
+      expect(argConfig.type).toBeInstanceOf(GraphQLNonNull);
+      expect(argConfig.type.toString()).toBe('[CreateManyUserInput!]!');
+    });
+    it('should have `records` arg as Plural', () => {
+      const resolver = createMany(UserModel, UserTC);
+      const argConfig: any = resolver.getArgConfig('records');
+      expect(argConfig.type.ofType).toBeInstanceOf(GraphQLList);
+      expect(argConfig.type.ofType.toString()).toBe('[CreateManyUserInput!]');
+    });
+    it('should have `records` arg internal item as required', () => {
+      const resolver = createMany(UserModel, UserTC);
+      const argConfig: any = resolver.getArgConfig('records');
+      expect(argConfig.type).toBeInstanceOf(GraphQLNonNull);
+      expect(argConfig.type.ofType.ofType.toString()).toBe('CreateManyUserInput!');
+    });
+  });
+
+  describe('Resolver.resolve():Promise', () => {
+    it('should be promise', () => {
+      const result = createMany(UserModel, UserTC).resolve({});
+      expect(result).toBeInstanceOf(Promise);
+      result.catch(() => 'catch error if appear, hide it from mocha');
+    });
+
+    it('should rejected with Error if args.records is empty', async () => {
+      const result = createMany(UserModel, UserTC).resolve({ args: {} });
+      await expect(result).rejects.toMatchSnapshot();
+    });
+
+    it('should rejected with Error if args.records is not array', async () => {
+      const result = createMany(UserModel, UserTC).resolve({ args: { records: {} } });
+      await expect(result).rejects.toMatchSnapshot();
+    });
+
+    it('should rejected with Error if args.records is empty array', async () => {
+      const result = createMany(UserModel, UserTC).resolve({
+        args: { records: [] },
+      });
+      await expect(result).rejects.toMatchSnapshot();
+    });
+
+    it('should rejected with Error if args.records is array with empty items', async () => {
+      const result = createMany(UserModel, UserTC).resolve({
+        args: { records: [{ name: 'fails' }, {}] },
+      });
+      await expect(result).rejects.toMatchSnapshot();
+    });
+
+    it('should return payload.recordIds', async () => {
+      const result = await createMany(UserModel, UserTC).resolve({
+        args: {
+          records: [{ name: 'newName' }],
+        },
+      });
+      expect(result.recordIds).toBeTruthy();
+    });
+
+    it('should create documents with args.records and match createCount', async () => {
+      const result = await createMany(UserModel, UserTC).resolve({
+        args: {
+          records: [{ name: 'newName0' }, { name: 'newName1' }],
+        },
+      });
+      expect(result.createCount).toBe(2);
+      expect(result.records[0].name).toBe('newName0');
+      expect(result.records[1].name).toBe('newName1');
+    });
+
+    it('should save documents to database', async () => {
+      const checkedName = 'nameForMongoDB';
+      const res = await createMany(UserModel, UserTC).resolve({
+        args: {
+          records: [{ name: checkedName }, { name: checkedName }],
+        },
+      });
+
+      const docs = await UserModel.collection.find({ _id: { $in: res.recordIds } }).toArray();
+      expect(docs.length).toBe(2);
+      expect(docs[0].name).toBe(checkedName);
+      expect(docs[1].name).toBe(checkedName);
+    });
+
+    it('should return payload.records', async () => {
+      const result = await createMany(UserModel, UserTC).resolve({
+        args: {
+          records: [{ name: 'NewUser' }],
+        },
+      });
+      expect(result.records[0]._id).toBe(result.recordIds[0]);
+    });
+
+    it('should return mongoose documents', async () => {
+      const result = await createMany(UserModel, UserTC).resolve({
+        args: { records: [{ name: 'NewUser' }] },
+      });
+      expect(result.records[0]).toBeInstanceOf(UserModel);
+    });
+
+    it('should call `beforeRecordMutate` method with each created `record` and `resolveParams` as args', async () => {
+      const result = await createMany(UserModel, UserTC).resolve({
+        args: { records: [{ name: 'NewUser0' }, { name: 'NewUser1' }] },
+        context: { ip: '1.1.1.1' },
+        beforeRecordMutate: (record, rp) => {
+          record.name = 'OverridedName';
+          record.someDynamic = rp.context.ip;
+          return record;
+        },
+      });
+      expect(result.records[0]).toBeInstanceOf(UserModel);
+      expect(result.records[1]).toBeInstanceOf(UserModel);
+      expect(result.records[0].name).toBe('OverridedName');
+      expect(result.records[1].name).toBe('OverridedName');
+      expect(result.records[0].someDynamic).toBe('1.1.1.1');
+      expect(result.records[1].someDynamic).toBe('1.1.1.1');
+    });
+
+    it('should execute hooks on save', async () => {
+      schemaComposer.clear();
+      const ClonedUserSchema = UserModel.schema.clone();
+
+      ClonedUserSchema.pre('save', function(next) {
+        this.name = 'ChangedAgain';
+        this.age = 18;
+        return next();
+      });
+
+      const ClonedUserModel = mongoose.model('UserClone', ClonedUserSchema);
+
+      const ClonedUserTC = convertModelToGraphQL(ClonedUserModel, 'UserClone', schemaComposer);
+      ClonedUserTC.setRecordIdFn(source => (source ? `${source._id}` : ''));
+
+      const result = await createMany(ClonedUserModel, ClonedUserTC).resolve({
+        args: { records: [{ name: 'NewUser0' }, { name: 'NewUser1' }] },
+        context: { ip: '1.1.1.1' },
+        beforeRecordMutate: (record, rp) => {
+          record.name = 'OverridedName';
+          record.someDynamic = rp.context.ip;
+          return record;
+        },
+      });
+      expect(result.records[0]).toBeInstanceOf(ClonedUserModel);
+      expect(result.records[1]).toBeInstanceOf(ClonedUserModel);
+      expect(result.records[0].age).toBe(18);
+      expect(result.records[1].age).toBe(18);
+      expect(result.records[0].name).toBe('ChangedAgain');
+      expect(result.records[1].name).toBe('ChangedAgain');
+      expect(result.records[0].someDynamic).toBe('1.1.1.1');
+      expect(result.records[1].someDynamic).toBe('1.1.1.1');
+    });
+  });
+
+  describe('Resolver.getType()', () => {
+    it('should have correct output type name', () => {
+      const outputType: any = createMany(UserModel, UserTC).getType();
+      expect(outputType.name).toBe(`CreateMany${UserTC.getTypeName()}Payload`);
+    });
+
+    it('should have recordIds field, NonNull List', () => {
+      const outputType: any = createMany(UserModel, UserTC).getType();
+      const recordIdField = new TypeComposer(outputType).getFieldConfig('recordIds');
+      expect(recordIdField.type).toEqual(new GraphQLNonNull(GraphQLList(GraphQLMongoID)));
+    });
+
+    it('should have records field, NonNull List', () => {
+      const outputType: any = createMany(UserModel, UserTC).getType();
+      const recordField = new TypeComposer(outputType).getFieldConfig('records');
+      expect(recordField.type).toEqual(new GraphQLNonNull(GraphQLList(UserTC.getType())));
+    });
+
+    it('should have createCount field, Int', () => {
+      const outputType: any = createMany(UserModel, UserTC).getType();
+      const recordField = new TypeComposer(outputType).getFieldConfig('createCount');
+      expect(recordField.type).toEqual(new GraphQLNonNull(GraphQLInt));
+    });
+
+    it('should reuse existed outputType', () => {
+      const outputTypeName = `CreateMany${UserTC.getTypeName()}Payload`;
+      const existedType = TypeComposer.create(outputTypeName);
+      schemaComposer.set(outputTypeName, existedType);
+      const outputType = createMany(UserModel, UserTC).getType();
+      expect(outputType).toBe(existedType.getType());
+    });
+  });
+});

--- a/src/resolvers/createMany.d.ts
+++ b/src/resolvers/createMany.d.ts
@@ -1,0 +1,8 @@
+import { Resolver, TypeComposer } from 'graphql-compose';
+import { Model } from 'mongoose';
+import { GenResolverOpts } from './index';
+
+export default function createMany(
+  model: Model<any>,
+  tc: TypeComposer<any>,
+  opts?: GenResolverOpts): Resolver<any, any>;

--- a/src/resolvers/createMany.js
+++ b/src/resolvers/createMany.js
@@ -1,0 +1,118 @@
+/* @flow */
+
+import type { TypeComposer, Resolver } from 'graphql-compose';
+import { graphql } from 'graphql-compose';
+import type { MongooseModel } from 'mongoose';
+import { recordHelperArgs } from './helpers';
+import type { ExtendedResolveParams, GenResolverOpts } from './index';
+
+async function createSingle(
+  model: MongooseModel,
+  tc: TypeComposer,
+  recordData: any,
+  resolveParams: ExtendedResolveParams
+) {
+  // eslint-disable-next-line new-cap
+  let doc = new model(recordData);
+  if (resolveParams.beforeRecordMutate) {
+    doc = await resolveParams.beforeRecordMutate(doc, resolveParams);
+    if (!doc) return null;
+  }
+
+  return doc.save();
+}
+
+export default function createMany(
+  model: MongooseModel,
+  tc: TypeComposer,
+  opts?: GenResolverOpts
+): Resolver {
+  if (!model || !model.modelName || !model.schema) {
+    throw new Error('First arg for Resolver createMany() should be instance of Mongoose Model.');
+  }
+
+  if (!tc || tc.constructor.name !== 'TypeComposer') {
+    throw new Error('Second arg for Resolver createMany() should be instance of TypeComposer.');
+  }
+
+  const outputTypeName = `CreateMany${tc.getTypeName()}Payload`;
+  const outputType = tc.constructor.schemaComposer.getOrCreateTC(outputTypeName, t => {
+    t.addFields({
+      recordIds: {
+        type: '[MongoID]!',
+        description: 'Created document ID',
+      },
+      records: {
+        type: new graphql.GraphQLNonNull(tc.getTypePlural()),
+        description: 'Created documents',
+      },
+      createCount: {
+        type: 'Int!',
+        description: 'Count of all documents created',
+      },
+    });
+  });
+
+  const resolver = new tc.constructor.schemaComposer.Resolver({
+    name: 'createMany',
+    kind: 'mutation',
+    description: 'Creates Many documents with mongoose defaults, setters, hooks and validation',
+    type: outputType,
+    args: {
+      records: {
+        type: new graphql.GraphQLNonNull(
+          graphql.GraphQLList(
+            (recordHelperArgs(tc, {
+              recordTypeName: `CreateMany${tc.getTypeName()}Input`,
+              removeFields: ['id', '_id'],
+              isRequired: true,
+              ...(opts && opts.records),
+            }).record: any).type
+          )
+        ),
+      },
+    },
+    resolve: async (resolveParams: ExtendedResolveParams) => {
+      const recordData = (resolveParams.args && resolveParams.args.records) || [];
+
+      if (!Array.isArray(recordData) || recordData.length === 0) {
+        throw new Error(
+          `${tc.getTypeName()}.createMany resolver requires args.records to be an Array and must contain at least one record`
+        );
+      }
+
+      for (const record of recordData) {
+        if (!(typeof record === 'object') || Object.keys(record).length === 0) {
+          throw new Error(
+            `${tc.getTypeName()}.createMany resolver requires args.records to contain non-empty records, with at least one value`
+          );
+        }
+      }
+
+      const recordPromises = [];
+      // concurrently create docs
+      for (const record of recordData) {
+        recordPromises.push(createSingle(model, tc, record, resolveParams));
+      }
+
+      const results = await Promise.all(recordPromises);
+      const returnObj = {
+        records: [],
+        recordIds: [],
+        createCount: 0,
+      };
+
+      for (const doc of results) {
+        if (doc) {
+          returnObj.createCount += 1;
+          returnObj.records.push(doc);
+          returnObj.recordIds.push(doc._id);
+        }
+      }
+
+      return returnObj;
+    },
+  });
+
+  return resolver;
+}

--- a/src/resolvers/helpers/index.js
+++ b/src/resolvers/helpers/index.js
@@ -17,4 +17,5 @@ export const MergeAbleHelperArgsOpts = {
   limit: getLimitHelperArgsOptsMap(),
   filter: getFilterHelperArgOptsMap(),
   record: getRecordHelperArgsOptsMap(),
+  records: getRecordHelperArgsOptsMap(),
 };

--- a/src/resolvers/index.d.ts
+++ b/src/resolvers/index.d.ts
@@ -4,6 +4,7 @@ import connection from './connection';
 import count from './count';
 
 import createOne from './createOne';
+import createMany from './createMany';
 
 import findById from './findById';
 import findByIds from './findByIds';
@@ -26,6 +27,7 @@ export type GenResolverOpts = {
   filter?: FilterHelperArgsOpts,
   sort?: SortHelperArgsOpts,
   record?: RecordHelperArgsOpts,
+  records?: RecordHelperArgsOpts,
   limit?: LimitHelperArgsOpts,
 };
 
@@ -48,6 +50,7 @@ export {
   removeOne,
   removeMany,
   createOne,
+  createMany,
   count,
   pagination,
   connection,
@@ -67,6 +70,7 @@ export const EMCResolvers: {
   removeOne: 'removeOne',
   removeMany: 'removeMany',
   createOne: 'createOne',
+  createMany: 'createMany',
   count: 'count',
   connection: 'connection',
   pagination: 'pagination',

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,38 +1,40 @@
 /* @flow */
 
-import type { MongooseQuery } from 'mongoose';
 import type { ResolveParams } from 'graphql-compose';
+import type { MongooseQuery } from 'mongoose';
+import connection from './connection';
+import count from './count';
+import createMany from './createMany';
+
+import createOne from './createOne';
 
 import findById from './findById';
 import findByIds from './findByIds';
-import findOne from './findOne';
 import findMany from './findMany';
-
-import updateById from './updateById';
-import updateOne from './updateOne';
-import updateMany from './updateMany';
-
-import removeById from './removeById';
-import removeOne from './removeOne';
-import removeMany from './removeMany';
-
-import createOne from './createOne';
-import count from './count';
-
-import pagination from './pagination';
-import connection from './connection';
+import findOne from './findOne';
 
 import type {
   FilterHelperArgsOpts,
-  SortHelperArgsOpts,
-  RecordHelperArgsOpts,
   LimitHelperArgsOpts,
+  RecordHelperArgsOpts,
+  SortHelperArgsOpts,
 } from './helpers';
+
+import pagination from './pagination';
+
+import removeById from './removeById';
+import removeMany from './removeMany';
+import removeOne from './removeOne';
+
+import updateById from './updateById';
+import updateMany from './updateMany';
+import updateOne from './updateOne';
 
 export type GenResolverOpts = {
   filter?: FilterHelperArgsOpts,
   sort?: SortHelperArgsOpts,
   record?: RecordHelperArgsOpts,
+  records?: RecordHelperArgsOpts,
   limit?: LimitHelperArgsOpts,
 };
 
@@ -55,6 +57,7 @@ export {
   removeOne,
   removeMany,
   createOne,
+  createMany,
   count,
   pagination,
   connection,
@@ -73,6 +76,7 @@ export function getAvailableNames(): string[] {
     'removeOne',
     'removeMany',
     'createOne',
+    'createMany',
     'count',
     'pagination', // should be defined after `findMany` and `count` resolvers
     'connection', // should be defined after `findMany` and `count` resolvers
@@ -92,6 +96,7 @@ export const EMCResolvers = {
   removeOne: 'removeOne',
   removeMany: 'removeMany',
   createOne: 'createOne',
+  createMany: 'createMany',
   count: 'count',
   connection: 'connection',
   pagination: 'pagination',


### PR DESCRIPTION
A `createMany` resolver that takes in an array of records, creates them all concurrently.
It works in a way that it allows you to use the `beforeRecordMutate` hook on each document before it is saved, also all validations, save hooks are runned by mongoose.

It kind of resolves the first part of this issue #35 by @andersonlin

```js
const UserSchema = new mongoose.Schema({
  name: String,
  age: Number
})

const UserModel = mongoose.model('User', UserSchema);
const UserTC = composeWithMongoose(UserModel);

schemaComposer.rootMutatution().addFields({
  userCreateMany: UserTC.getResolver('createMany'),
})

const schema = schemaComposer.build();

graphql(
  schema, 
  `mutation {
     userCreateMany(records: [ { name: "Create", age: 1 }, { name: "Many", age: 2 } ]) {
       recordIds
       records {
         _id
         name
         age
       }
       createCount
     }
  }` 
)
.then(({data}) => {
 console.log(data.userCreateMany.recordIds) -> [ '5b71344586fd98fec759ee64', '5b71344586fd98fec759ee65' ] // an array of successfully created records IDs
console.log(data.userCreateMany.records) -> [ { _id: '5b71344586fd98fec759ee64', name: 'Create', age: 1 }, { _id: '5b71344586fd98fec759ee65', name: 'Many', age: 2 } ]  // an array of all created documents
 console.log(data.userCreateMany.createCount)  -> 2 // an integer which is a count of all created documents
})
```
