### PR TITLE
Missing createMany in TypeConverterResolverOpts for TypeScript

### DIFF
--- a/src/composeWithMongoose.d.ts
+++ b/src/composeWithMongoose.d.ts
@@ -1,126 +1,138 @@
-import { InputTypeComposer, SchemaComposer, TypeComposer } from 'graphql-compose';
+import {
+  InputTypeComposer,
+  SchemaComposer,
+  TypeComposer,
+} from 'graphql-compose';
 import { Document, Model } from 'mongoose';
 import { ConnectionSortMapOpts } from './resolvers/connection';
 import {
-  FilterHelperArgsOpts, LimitHelperArgsOpts, RecordHelperArgsOpts, SortHelperArgsOpts,
+  FilterHelperArgsOpts,
+  LimitHelperArgsOpts,
+  RecordHelperArgsOpts,
+  SortHelperArgsOpts,
 } from './resolvers/helpers';
 import { PaginationResolverOpts } from './resolvers/pagination';
 
 export type TypeConverterOpts = {
-  schemaComposer?: SchemaComposer<any>,
-  name?: string,
-  description?: string,
+  schemaComposer?: SchemaComposer<any>;
+  name?: string;
+  description?: string;
   fields?: {
-    only?: string[],
-    remove?: string[],
-  },
-  inputType?: TypeConverterInputTypeOpts,
-  resolvers?: false | TypeConverterResolversOpts,
+    only?: string[];
+    remove?: string[];
+  };
+  inputType?: TypeConverterInputTypeOpts;
+  resolvers?: false | TypeConverterResolversOpts;
 };
 
 export type TypeConverterInputTypeOpts = {
-  name?: string,
-  description?: string,
+  name?: string;
+  description?: string;
   fields?: {
-    only?: string[],
-    remove?: string[],
-    required?: string[],
-  },
+    only?: string[];
+    remove?: string[];
+    required?: string[];
+  };
 };
 
 export type TypeConverterResolversOpts = {
-  findById?: false,
+  findById?: false;
   findByIds?:
     | false
     | {
-      limit?: LimitHelperArgsOpts | false,
-      sort?: SortHelperArgsOpts | false,
-    },
+        limit?: LimitHelperArgsOpts | false;
+        sort?: SortHelperArgsOpts | false;
+      };
   findOne?:
     | false
     | {
-      filter?: FilterHelperArgsOpts | false,
-      sort?: SortHelperArgsOpts | false,
-      skip?: false,
-    },
+        filter?: FilterHelperArgsOpts | false;
+        sort?: SortHelperArgsOpts | false;
+        skip?: false;
+      };
   findMany?:
     | false
     | {
-      filter?: FilterHelperArgsOpts | false,
-      sort?: SortHelperArgsOpts | false,
-      limit?: LimitHelperArgsOpts | false,
-      skip?: false,
-    },
+        filter?: FilterHelperArgsOpts | false;
+        sort?: SortHelperArgsOpts | false;
+        limit?: LimitHelperArgsOpts | false;
+        skip?: false;
+      };
   updateById?:
     | false
     | {
-      record?: RecordHelperArgsOpts | false,
-    },
+        record?: RecordHelperArgsOpts | false;
+      };
   updateOne?:
     | false
     | {
-      input?: RecordHelperArgsOpts | false,
-      filter?: FilterHelperArgsOpts | false,
-      sort?: SortHelperArgsOpts | false,
-      skip?: false,
-    },
+        input?: RecordHelperArgsOpts | false;
+        filter?: FilterHelperArgsOpts | false;
+        sort?: SortHelperArgsOpts | false;
+        skip?: false;
+      };
   updateMany?:
     | false
     | {
-      record?: RecordHelperArgsOpts | false,
-      filter?: FilterHelperArgsOpts | false,
-      sort?: SortHelperArgsOpts | false,
-      limit?: LimitHelperArgsOpts | false,
-      skip?: false,
-    },
-  removeById?: false,
+        record?: RecordHelperArgsOpts | false;
+        filter?: FilterHelperArgsOpts | false;
+        sort?: SortHelperArgsOpts | false;
+        limit?: LimitHelperArgsOpts | false;
+        skip?: false;
+      };
+  removeById?: false;
   removeOne?:
     | false
     | {
-      filter?: FilterHelperArgsOpts | false,
-      sort?: SortHelperArgsOpts | false,
-    },
+        filter?: FilterHelperArgsOpts | false;
+        sort?: SortHelperArgsOpts | false;
+      };
   removeMany?:
     | false
     | {
-      filter?: FilterHelperArgsOpts | false,
-    },
+        filter?: FilterHelperArgsOpts | false;
+      };
   createOne?:
     | false
     | {
-      record?: RecordHelperArgsOpts | false,
-    },
-	createMany?:
+        record?: RecordHelperArgsOpts | false;
+      };
+  createMany?:
     | false
     | {
-      record?: RecordHelperArgsOpts | false,
-    },
+        record?: RecordHelperArgsOpts | false;
+      };
   count?:
     | false
     | {
-      filter?: FilterHelperArgsOpts | false,
-    },
-  connection?: ConnectionSortMapOpts | false,
-  pagination?: PaginationResolverOpts | false,
+        filter?: FilterHelperArgsOpts | false;
+      };
+  connection?: ConnectionSortMapOpts | false;
+  pagination?: PaginationResolverOpts | false;
 };
 
 export function composeWithMongoose(
   model: Model<any>,
-  opts?: TypeConverterOpts): TypeComposer<any>;
+  opts?: TypeConverterOpts,
+): TypeComposer<any>;
 
 export function prepareFields(
   tc: TypeComposer<any>,
-  opts: { only?: string[], remove?: string[] }): void;
+  opts: { only?: string[]; remove?: string[] },
+): void;
 
 export function prepareInputFields(
   inputTypeComposer: InputTypeComposer,
-  inputFieldsOpts: { only?: string[], remove?: string[], required?: string[] }): void;
+  inputFieldsOpts: { only?: string[]; remove?: string[]; required?: string[] },
+): void;
 
 export function createInputType(
   tc: TypeComposer<any>,
-  inputTypeOpts?: TypeConverterInputTypeOpts): void;
+  inputTypeOpts?: TypeConverterInputTypeOpts,
+): void;
 
 export function createResolvers<TDocument extends Document>(
   model: Model<TDocument>,
   tc: TypeComposer<any>,
-  opts: TypeConverterResolversOpts): void;
+  opts: TypeConverterResolversOpts,
+): void;

--- a/src/composeWithMongoose.d.ts
+++ b/src/composeWithMongoose.d.ts
@@ -90,6 +90,11 @@ export type TypeConverterResolversOpts = {
     | {
       record?: RecordHelperArgsOpts | false,
     },
+	createMany?:
+    | false
+    | {
+      record?: RecordHelperArgsOpts | false,
+    },
   count?:
     | false
     | {

--- a/src/resolvers/createMany.js
+++ b/src/resolvers/createMany.js
@@ -61,7 +61,7 @@ export default function createMany(
     args: {
       records: {
         type: new graphql.GraphQLNonNull(
-          graphql.GraphQLList(
+          new graphql.GraphQLList(
             (recordHelperArgs(tc, {
               recordTypeName: `CreateMany${tc.getTypeName()}Input`,
               removeFields: ['id', '_id'],


### PR DESCRIPTION
A small problem I happened to run across with the typescript definition for TypeConverterResolverOpts - it is missing the property for createMany.  It is present in the equivalent flow type definition.
