### PR TITLE
feat: add support for required properties

### DIFF
--- a/flow-typed/npm/mongoose_v4.x.x.js
+++ b/flow-typed/npm/mongoose_v4.x.x.js
@@ -184,6 +184,7 @@ type Mongoose$SchemaField<Schema> = {
   options?: ?{
     description: ?string
   },
+  isRequired?: boolean,
   enumValues?: ?(string[]),
   schema?: Schema,
   _index?: ?{ [optionName: string]: mixed }

--- a/src/__mocks__/userModel.js
+++ b/src/__mocks__/userModel.js
@@ -116,7 +116,7 @@ const UserRequiredSchema: SchemaType<any> = new Schema({
   name: {
     type: String,
     description: 'Person name',
-    required: true
+    required: true,
   },
 });
 

--- a/src/__mocks__/userModel.js
+++ b/src/__mocks__/userModel.js
@@ -90,6 +90,11 @@ const UserSchema: SchemaType<any> = new Schema(
       periods: [{ from: Number, to: Number }],
     },
 
+    requiredField: {
+      type: String,
+      required: true,
+    },
+
     // createdAt, created via option `timastamp: true` (see bottom)
     // updatedAt, created via option `timastamp: true` (see bottom)
   },

--- a/src/__mocks__/userModel.js
+++ b/src/__mocks__/userModel.js
@@ -90,11 +90,6 @@ const UserSchema: SchemaType<any> = new Schema(
       periods: [{ from: Number, to: Number }],
     },
 
-    requiredField: {
-      type: String,
-      required: true,
-    },
-
     // createdAt, created via option `timastamp: true` (see bottom)
     // updatedAt, created via option `timastamp: true` (see bottom)
   },
@@ -116,3 +111,15 @@ UserSchema.virtual('nameVirtual').get(function() {
 const UserModel = mongoose.model('User', UserSchema);
 
 export { UserSchema, UserModel };
+
+const UserRequiredSchema: SchemaType<any> = new Schema({
+  name: {
+    type: String,
+    description: 'Person name',
+    required: true
+  },
+});
+
+const UserRequiredModel = mongoose.model('UserRequired', UserRequiredSchema);
+
+export { UserRequiredSchema, UserRequiredModel };

--- a/src/__tests__/fieldConverter-test.js
+++ b/src/__tests__/fieldConverter-test.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-expressions, no-template-curly-in-string */
 
 import { EnumTypeComposer, schemaComposer } from 'graphql-compose';
-import { UserModel } from '../__mocks__/userModel';
+import { UserModel, UserRequiredModel } from '../__mocks__/userModel';
 import {
   deriveComplexType,
   getFieldsFromModel,
@@ -111,8 +111,8 @@ describe('fieldConverter', () => {
 
   describe('convertFieldToGraphQL()', () => {
     it('should set required field', () => {
-      const tc = convertModelToGraphQL(UserModel, 'User', schemaComposer);
-      expect(tc.isFieldNonNull('requiredField')).toBeTruthy();
+      const tc = convertModelToGraphQL(UserRequiredModel, 'UserRequired', schemaComposer);
+      expect(tc.isFieldNonNull('name')).toBeTruthy();
     });
   });
 

--- a/src/__tests__/fieldConverter-test.js
+++ b/src/__tests__/fieldConverter-test.js
@@ -14,6 +14,7 @@ import {
   enumToGraphQL,
   documentArrayToGraphQL,
   referenceToGraphQL,
+  convertModelToGraphQL,
 } from '../fieldsConverter';
 import GraphQLMongoID from '../types/mongoid';
 
@@ -105,6 +106,13 @@ describe('fieldConverter', () => {
 
     it('schould derive MIXED mongoose type', () => {
       expect(deriveComplexType(fields.someDynamic)).toBe(ComplexTypes.MIXED);
+    });
+  });
+
+  describe('convertFieldToGraphQL()', () => {
+    it('should set required field', () => {
+      const tc = convertModelToGraphQL(UserModel, 'User', schemaComposer);
+      expect(tc.isFieldNonNull('requiredField')).toBeTruthy();
     });
   });
 

--- a/src/fieldsConverter.js
+++ b/src/fieldsConverter.js
@@ -127,6 +127,7 @@ export function convertModelToGraphQL(
     return schemaComposer.getTC(model.schema);
   }
 
+  const requiredFields = [];
   const typeComposer = schemaComposer.getOrCreateTC(typeName);
   // $FlowFixMe await landing graphql-compose@4.4.2 or above
   schemaComposer.set(model.schema, typeComposer);
@@ -137,6 +138,11 @@ export function convertModelToGraphQL(
 
   Object.keys(mongooseFields).forEach(fieldName => {
     const mongooseField: MongooseFieldT = mongooseFields[fieldName];
+
+    if (mongooseField.isRequired) {
+      requiredFields.push(fieldName);
+    }
+
     graphqlFields[fieldName] = {
       type: convertFieldToGraphQL(mongooseField, typeName, schemaComposer),
       description: _getFieldDescription(mongooseField),
@@ -158,6 +164,7 @@ export function convertModelToGraphQL(
   });
 
   typeComposer.addFields(graphqlFields);
+  requiredFields.map(f => typeComposer.makeFieldNonNull(f));
   return typeComposer;
 }
 

--- a/src/utils/getIndexesFromModel.js
+++ b/src/utils/getIndexesFromModel.js
@@ -20,9 +20,9 @@ function isSpecificIndex(idx) {
 }
 
 /*
-* Get mongoose model, and return array of fields with indexes.
-*  MongooseModel  ->  [ { _id: 1 }, { name: 1, surname: -1 } ]
-*/
+ * Get mongoose model, and return array of fields with indexes.
+ *  MongooseModel  ->  [ { _id: 1 }, { name: 1, surname: -1 } ]
+ */
 export function getIndexesFromModel(
   mongooseModel: MongooseModel,
   opts: getIndexesFromModelOpts = {}


### PR DESCRIPTION
add feature from https://github.com/graphql-compose/graphql-compose-mongoose/issues/144

Required fields from mongoose.Schema were not being converted to a NonNull Type.

This checks if field is required and make them NonNull