### PR TITLE
Fix: required fields only apply to Create resolvers

### DIFF
--- a/src/__mocks__/userModel.js
+++ b/src/__mocks__/userModel.js
@@ -111,15 +111,3 @@ UserSchema.virtual('nameVirtual').get(function() {
 const UserModel = mongoose.model('User', UserSchema);
 
 export { UserSchema, UserModel };
-
-const UserRequiredSchema: SchemaType<any> = new Schema({
-  name: {
-    type: String,
-    description: 'Person name',
-    required: true,
-  },
-});
-
-const UserRequiredModel = mongoose.model('UserRequired', UserRequiredSchema);
-
-export { UserRequiredSchema, UserRequiredModel };

--- a/src/__tests__/fieldConverter-test.js
+++ b/src/__tests__/fieldConverter-test.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-expressions, no-template-curly-in-string */
 
 import { EnumTypeComposer, schemaComposer } from 'graphql-compose';
-import { UserModel, UserRequiredModel } from '../__mocks__/userModel';
+import { UserModel } from '../__mocks__/userModel';
 import {
   deriveComplexType,
   getFieldsFromModel,
@@ -14,7 +14,6 @@ import {
   enumToGraphQL,
   documentArrayToGraphQL,
   referenceToGraphQL,
-  convertModelToGraphQL,
 } from '../fieldsConverter';
 import GraphQLMongoID from '../types/mongoid';
 
@@ -106,13 +105,6 @@ describe('fieldConverter', () => {
 
     it('schould derive MIXED mongoose type', () => {
       expect(deriveComplexType(fields.someDynamic)).toBe(ComplexTypes.MIXED);
-    });
-  });
-
-  describe('convertFieldToGraphQL()', () => {
-    it('should set required field', () => {
-      const tc = convertModelToGraphQL(UserRequiredModel, 'UserRequired', schemaComposer);
-      expect(tc.isFieldNonNull('name')).toBeTruthy();
     });
   });
 

--- a/src/fieldsConverter.js
+++ b/src/fieldsConverter.js
@@ -127,7 +127,6 @@ export function convertModelToGraphQL(
     return schemaComposer.getTC(model.schema);
   }
 
-  const requiredFields = [];
   const typeComposer = schemaComposer.getOrCreateTC(typeName);
   // $FlowFixMe await landing graphql-compose@4.4.2 or above
   schemaComposer.set(model.schema, typeComposer);
@@ -138,10 +137,6 @@ export function convertModelToGraphQL(
 
   Object.keys(mongooseFields).forEach(fieldName => {
     const mongooseField: MongooseFieldT = mongooseFields[fieldName];
-
-    if (mongooseField.isRequired) {
-      requiredFields.push(fieldName);
-    }
 
     graphqlFields[fieldName] = {
       type: convertFieldToGraphQL(mongooseField, typeName, schemaComposer),
@@ -164,7 +159,6 @@ export function convertModelToGraphQL(
   });
 
   typeComposer.addFields(graphqlFields);
-  requiredFields.map(f => typeComposer.makeFieldNonNull(f));
   return typeComposer;
 }
 

--- a/src/resolvers/createMany.js
+++ b/src/resolvers/createMany.js
@@ -35,7 +35,7 @@ export default function createMany(
     throw new Error('Second arg for Resolver createMany() should be instance of TypeComposer.');
   }
 
-  const tree = model.schema.tree;
+  const tree = model.schema.obj;
   const requiredFields = [];
   for (const field in tree) {
     if (tree.hasOwnProperty(field)) {

--- a/src/resolvers/createMany.js
+++ b/src/resolvers/createMany.js
@@ -35,6 +35,17 @@ export default function createMany(
     throw new Error('Second arg for Resolver createMany() should be instance of TypeComposer.');
   }
 
+  const tree = model.schema.tree;
+  const requiredFields = [];
+  for (const field in tree) {
+    if (tree.hasOwnProperty(field)) {
+      const fieldOptions = tree[field];
+      if (fieldOptions.required) {
+        requiredFields.push(field);
+      }
+    }
+  }
+
   const outputTypeName = `CreateMany${tc.getTypeName()}Payload`;
   const outputType = tc.constructor.schemaComposer.getOrCreateTC(outputTypeName, t => {
     t.addFields({
@@ -66,6 +77,7 @@ export default function createMany(
               recordTypeName: `CreateMany${tc.getTypeName()}Input`,
               removeFields: ['id', '_id'],
               isRequired: true,
+              requiredFields,
               ...(opts && opts.records),
             }).record: any).type
           )

--- a/src/resolvers/createOne.js
+++ b/src/resolvers/createOne.js
@@ -19,7 +19,7 @@ export default function createOne(
     throw new Error('Second arg for Resolver createOne() should be instance of TypeComposer.');
   }
 
-  const tree = model.schema.tree;
+  const tree = model.schema.obj;
   const requiredFields = [];
   for (const field in tree) {
     if (tree.hasOwnProperty(field)) {

--- a/src/resolvers/createOne.js
+++ b/src/resolvers/createOne.js
@@ -19,6 +19,17 @@ export default function createOne(
     throw new Error('Second arg for Resolver createOne() should be instance of TypeComposer.');
   }
 
+  const tree = model.schema.tree;
+  const requiredFields = [];
+  for (const field in tree) {
+    if (tree.hasOwnProperty(field)) {
+      const fieldOptions = tree[field];
+      if (fieldOptions.required) {
+        requiredFields.push(field);
+      }
+    }
+  }
+
   const outputTypeName = `CreateOne${tc.getTypeName()}Payload`;
   const outputType = tc.constructor.schemaComposer.getOrCreateTC(outputTypeName, t => {
     t.addFields({
@@ -43,6 +54,7 @@ export default function createOne(
         recordTypeName: `CreateOne${tc.getTypeName()}Input`,
         removeFields: ['id', '_id'],
         isRequired: true,
+        requiredFields,
         ...(opts && opts.record),
       }),
     },


### PR DESCRIPTION
Fix for https://github.com/graphql-compose/graphql-compose-mongoose/pull/145

 - Removes the inheritance of required fields from the Mongoose schema
 - Adds to Create Resolvers (CreateOne, CreateMany) required fields that reflects the mongoose schema 