### PR TITLE
feat: convert arrays without using element index [utils/toMongoDottedObject]

### DIFF
--- a/src/resolvers/helpers/filter.js
+++ b/src/resolvers/helpers/filter.js
@@ -4,7 +4,7 @@
 import type { TypeComposer, ComposeFieldConfigArgumentMap } from 'graphql-compose';
 import type { MongooseModel } from 'mongoose';
 import GraphQLMongoID from '../../types/mongoid';
-import { isObject, toMongoDottedObject, getIndexedFieldNamesForGraphQL } from '../../utils';
+import { isObject, toMongoFilterDottedObject, getIndexedFieldNamesForGraphQL } from '../../utils';
 import type { ExtendedResolveParams } from '../index';
 import {
   type FilterOperatorsOpts,
@@ -112,7 +112,7 @@ export function filterHelper(resolveParams: ExtendedResolveParams): void {
     });
     if (Object.keys(clearedFilter).length > 0) {
       // eslint-disable-next-line
-      resolveParams.query = resolveParams.query.where(toMongoDottedObject(clearedFilter));
+      resolveParams.query = resolveParams.query.where(toMongoFilterDottedObject(clearedFilter));
     }
 
     processFilterOperators(filter, resolveParams);

--- a/src/resolvers/updateMany.js
+++ b/src/resolvers/updateMany.js
@@ -14,7 +14,7 @@ import {
   sortHelper,
   sortHelperArgs,
 } from './helpers';
-import toMongoDottedObject from '../utils/toMongoDottedObject';
+import { toMongoDottedObject } from '../utils/toMongoDottedObject';
 import type { ExtendedResolveParams, GenResolverOpts } from './index';
 
 export default function updateMany(

--- a/src/utils/__tests__/toMongoDottedObject-test.js
+++ b/src/utils/__tests__/toMongoDottedObject-test.js
@@ -51,4 +51,8 @@ describe('toMongoDottedObject()', () => {
       'a.someField': id,
     });
   });
+
+  it('should dot array without index', () => {
+    expect(toMongoDottedObject({ a: [{ b: 1 }, { c: 2 }] })).toEqual({ 'a.b': 1, 'a.c': 2 });
+  });
 });

--- a/src/utils/__tests__/toMongoDottedObject-test.js
+++ b/src/utils/__tests__/toMongoDottedObject-test.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { Types } from 'mongoose';
-import toMongoDottedObject from '../toMongoDottedObject';
+import { toMongoDottedObject, toMongoFilterDottedObject } from '../toMongoDottedObject';
 
 describe('toMongoDottedObject()', () => {
   it('should dot nested objects', () => {
@@ -53,6 +53,60 @@ describe('toMongoDottedObject()', () => {
   });
 
   it('should dot array without index', () => {
-    expect(toMongoDottedObject({ a: [{ b: 1 }, { c: 2 }] })).toEqual({ 'a.b': 1, 'a.c': 2 });
+    expect(toMongoDottedObject({ a: [{ b: 1 }, { c: 2 }] })).toEqual({ 'a.0.b': 1, 'a.1.c': 2 });
+  });
+});
+
+describe('toMongoFilterDottedObject()', () => {
+  it('should dot nested objects', () => {
+    expect(toMongoFilterDottedObject({ a: { b: { c: 1 } } })).toEqual({ 'a.b.c': 1 });
+  });
+
+  it('should not dot query operators started with $', () => {
+    expect(toMongoFilterDottedObject({ a: { $in: [1, 2, 3] } })).toEqual({
+      a: { $in: [1, 2, 3] },
+    });
+    expect(toMongoFilterDottedObject({ a: { b: { $in: [1, 2, 3] } } })).toEqual({
+      'a.b': { $in: [1, 2, 3] },
+    });
+    expect(toMongoFilterDottedObject({ $or: [{ age: 1 }, { age: 2 }] })).toEqual({
+      $or: [{ age: 1 }, { age: 2 }],
+    });
+  });
+
+  it('should mix query operators started with $', () => {
+    expect(toMongoFilterDottedObject({ a: { $in: [1, 2, 3], $exists: true } })).toEqual({
+      a: { $in: [1, 2, 3], $exists: true },
+    });
+  });
+
+  it('should not mix query operators started with $ and regular fields', () => {
+    expect(toMongoFilterDottedObject({ a: { $exists: true, b: 3 } })).toEqual({
+      a: { $exists: true },
+      'a.b': 3,
+    });
+  });
+
+  it('should handle date object values as scalars', () => {
+    expect(toMongoFilterDottedObject({ dateField: new Date(100) })).toEqual({
+      dateField: new Date(100),
+    });
+  });
+
+  it('should handle date object values when nested', () => {
+    expect(toMongoFilterDottedObject({ a: { dateField: new Date(100) } })).toEqual({
+      'a.dateField': new Date(100),
+    });
+  });
+
+  it('should keep BSON ObjectId untouched', () => {
+    const id = new Types.ObjectId();
+    expect(toMongoFilterDottedObject({ a: { someField: id } })).toEqual({
+      'a.someField': id,
+    });
+  });
+
+  it('should dot array without index', () => {
+    expect(toMongoFilterDottedObject({ a: [{ b: 1 }, { c: 2 }] })).toEqual({ 'a.b': 1, 'a.c': 2 });
   });
 });

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -1,3 +1,3 @@
 export { isObject, upperFirst } from 'graphql-compose';
-export { default as toMongoDottedObject } from './toMongoDottedObject';
+export { toMongoDottedObject, toMongoFilterDottedObject } from './toMongoDottedObject';
 export * from './getIndexesFromModel';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { isObject, upperFirst } from 'graphql-compose';
-import toMongoDottedObject from './toMongoDottedObject';
+import { toMongoDottedObject, toMongoFilterDottedObject } from './toMongoDottedObject';
 
-export { toMongoDottedObject, isObject, upperFirst };
+export { toMongoDottedObject, toMongoFilterDottedObject, isObject, upperFirst };
 export * from './getIndexesFromModel';

--- a/src/utils/toMongoDottedObject.d.ts
+++ b/src/utils/toMongoDottedObject.d.ts
@@ -1,4 +1,10 @@
-export default function toMongoDottedObject(
+export function toMongoDottedObject(
+  obj: object,
+  target?: object,
+  path?: string[],
+): { [dottedPath: string]: any };
+
+export function toMongoFilterDottedObject(
   obj: object,
   target?: object,
   path?: string[],

--- a/src/utils/toMongoDottedObject.js
+++ b/src/utils/toMongoDottedObject.js
@@ -9,6 +9,7 @@ const ObjectId = Types.ObjectId;
  * { a: { b: { c: 1 }}} ->  { 'a.b.c': 1 }
  * { a: { $in: [ 1, 2, 3] }} ->  { 'a': { $in: [ 1, 2, 3] } }
  * { a: { b: { $in: [ 1, 2, 3] }}} ->  { 'a.b': { $in: [ 1, 2, 3] } }
+ * { a: [ { b: 1 }, { c: 2 }]} -> { 'a.b': 1, 'a.c': 2 }
  * Usage:
  *   var dotObject(obj)
  *   or
@@ -37,7 +38,7 @@ export default function toMongoDottedObject(
          };
        }
      } else if (Object(obj[key]) === obj[key] && !(obj[key] instanceof ObjectId)) {
-       toMongoDottedObject(obj[key], target, path.concat(key));
+       toMongoDottedObject(obj[key], target, Array.isArray(obj) ? path : path.concat(key));
      } else {
        target[path.concat(key).join('.')] = obj[key];
      }

--- a/src/utils/toMongoDottedObject.js
+++ b/src/utils/toMongoDottedObject.js
@@ -4,26 +4,7 @@ import { Types } from 'mongoose';
 
 const ObjectId = Types.ObjectId;
 
-/**
- * Convert object to dotted-key/value pair
- * { a: { b: { c: 1 }}} ->  { 'a.b.c': 1 }
- * { a: { $in: [ 1, 2, 3] }} ->  { 'a': { $in: [ 1, 2, 3] } }
- * { a: { b: { $in: [ 1, 2, 3] }}} ->  { 'a.b': { $in: [ 1, 2, 3] } }
- * { a: [ { b: 1 }, { c: 2 }]} -> { 'a.b': 1, 'a.c': 2 }
- * Usage:
- *   var dotObject(obj)
- *   or
- *   var target = {}; dotObject(obj, target)
- *
- * @param {Object} obj source object
- * @param {Object} target target object
- * @param {Array} path path array (internal)
- */
-export default function toMongoDottedObject(
-  obj: Object,
-  target?: Object = {},
-  path?: string[] = []
-): { [dottedPath: string]: mixed } {
+function _toMongoDottedObject(obj, target = {}, path = [], filter = false) {
   const objKeys = Object.keys(obj);
 
   /* eslint-disable */
@@ -38,7 +19,7 @@ export default function toMongoDottedObject(
          };
        }
      } else if (Object(obj[key]) === obj[key] && !(obj[key] instanceof ObjectId)) {
-       toMongoDottedObject(obj[key], target, Array.isArray(obj) ? path : path.concat(key));
+       _toMongoDottedObject(obj[key], target, Array.isArray(obj) && filter ? path : path.concat(key), filter);
      } else {
        target[path.concat(key).join('.')] = obj[key];
      }
@@ -50,4 +31,50 @@ export default function toMongoDottedObject(
 
    return target;
    /* eslint-enable */
+}
+
+/**
+ * Convert object to dotted-key/value pair
+ * { a: { b: { c: 1 }}} ->  { 'a.b.c': 1 }
+ * { a: { $in: [ 1, 2, 3] }} ->  { 'a': { $in: [ 1, 2, 3] } }
+ * { a: { b: { $in: [ 1, 2, 3] }}} ->  { 'a.b': { $in: [ 1, 2, 3] } }
+ * { a: [ { b: 1 }, { c: 2 }]} -> { 'a.0.b': 1, 'a.1.c': 2 }
+ * Usage:
+ *   var toMongoDottedObject(obj)
+ *   or
+ *   var target = {}; toMongoDottedObject(obj, target)
+ *
+ * @param {Object} obj source object
+ * @param {Object} target target object
+ * @param {Array} path path array (internal)
+ */
+export function toMongoDottedObject(
+  obj: Object,
+  target?: Object = {},
+  path?: string[] = []
+): { [dottedPath: string]: mixed } {
+  return _toMongoDottedObject(obj, target, path);
+}
+
+/**
+ * Convert object to dotted-key/value pair
+ * { a: { b: { c: 1 }}} ->  { 'a.b.c': 1 }
+ * { a: { $in: [ 1, 2, 3] }} ->  { 'a': { $in: [ 1, 2, 3] } }
+ * { a: { b: { $in: [ 1, 2, 3] }}} ->  { 'a.b': { $in: [ 1, 2, 3] } }
+ * { a: [ { b: 1 }, { c: 2 }]} -> { 'a.b': 1, 'a.c': 2 }
+ * Usage:
+ *   var toMongoFilterDottedObject(obj)
+ *   or
+ *   var target = {}; toMongoFilterDottedObject(obj, target)
+ *
+ * @param {Object} obj source object
+ * @param {Object} target target object
+ * @param {Array} path path array (internal)
+ */
+export function toMongoFilterDottedObject(
+  obj: Object,
+  target?: Object = {},
+  path?: string[] = []
+): { [dottedPath: string]: mixed } {
+  return _toMongoDottedObject(obj, target, path, true);
 }


### PR DESCRIPTION
This PR changes the way that the `toMongoDottedObject` works by not inserting the element index in the path when converting arrays, for example:
`{ a: [ { b: 1 }, { c: 2 }]}`
Will be converted to:
`{ 'a.b': 1, 'a.c': 2 }` instead of `{ 'a.0.b': 1, 'a.1.c': 2 }`

I noticed that in this comment (https://github.com/graphql-compose/graphql-compose/issues/132#issuecomment-413220699) @nodkz mentioned that:
> It's default behavior of MongoDB to search in the first object in the array field.

Which is true if the intended behaviour of converting arrays is to keep the element index. If that's the case then it's worth adding a test that covers that scenario and demonstrates that it's intended (I can update this PR to cover it)