### PR TITLE
Make field '_id' optional in filter argument

### DIFF
--- a/src/resolvers/helpers/filter.js
+++ b/src/resolvers/helpers/filter.js
@@ -69,6 +69,8 @@ export const filterHelperArgs = (
   const filterTypeName: string = opts.filterTypeName;
   const itc = typeComposer.getInputTypeComposer().clone(filterTypeName);
 
+  itc.makeOptional('_id');
+
   itc.addFields({
     _ids: [GraphQLMongoID],
   });


### PR DESCRIPTION
In some cases, some resolver were making the filter._id argument required.

This is a minor change that doesn't break any code.
since that all the arguments in Filter are optional unless required fields is defined in customizationOptions.

It seems to me, that in some cases the required of _id is inherited from the typecomposer and this logic only certifies that _id is required unless said so.