### PR TITLE
Fix flow/ts typings of TypeConverterResolversOpts.updateOne

### DIFF
--- a/src/composeWithMongoose.d.ts
+++ b/src/composeWithMongoose.d.ts
@@ -66,7 +66,7 @@ export type TypeConverterResolversOpts = {
   updateOne?:
     | false
     | {
-        input?: RecordHelperArgsOpts | false;
+        record?: RecordHelperArgsOpts | false;
         filter?: FilterHelperArgsOpts | false;
         sort?: SortHelperArgsOpts | false;
         skip?: false;

--- a/src/composeWithMongoose.js
+++ b/src/composeWithMongoose.js
@@ -70,7 +70,7 @@ export type TypeConverterResolversOpts = {
   updateOne?:
     | false
     | {
-        input?: RecordHelperArgsOpts | false,
+        record?: RecordHelperArgsOpts | false,
         filter?: FilterHelperArgsOpts | false,
         sort?: SortHelperArgsOpts | false,
         skip?: false,


### PR DESCRIPTION
Hi @nodkz (it's been a while!),

I've encountered a type error on this when removing the same field from the respective input types of updateOne and updateById. Indeed, the two do take a "record" argument, but the typings were incorrectly referring to an "input" argument for updateOne.