### PR TITLE
disable default required type for mongoose conditional required fields

### DIFF
--- a/src/resolvers/createMany.js
+++ b/src/resolvers/createMany.js
@@ -41,7 +41,7 @@ export default function createMany<TSource: MongooseDocument, TContext>(
   for (const field in tree) {
     if (tree.hasOwnProperty(field)) {
       const fieldOptions = tree[field];
-      if (fieldOptions.required) {
+      if (fieldOptions.required && typeof fieldOptions.required !== 'function') {
         requiredFields.push(field);
       }
     }

--- a/src/resolvers/createOne.js
+++ b/src/resolvers/createOne.js
@@ -26,7 +26,7 @@ export default function createOne<TSource: MongooseDocument, TContext>(
   for (const field in tree) {
     if (tree.hasOwnProperty(field)) {
       const fieldOptions = tree[field];
-      if (fieldOptions.required) {
+      if (fieldOptions.required && typeof fieldOptions.required !== 'function') {
         requiredFields.push(field);
       }
     }


### PR DESCRIPTION
This PR solves the problem of fields that are conditionally required in mongoose, but that are automatically converted to required in createOne and createMany in Graphql.

I couldn't find the related tests.