### PR TITLE
[WIP] Start of next major?

### DIFF
--- a/src/__mocks__/userModel.js
+++ b/src/__mocks__/userModel.js
@@ -47,6 +47,23 @@ const UserSchema: SchemaType<any> = new Schema(
       enum: ['male', 'female', 'ladyboy'],
     },
 
+    valid: {
+      type: String,
+      required: false,
+      validate: [
+        () => {
+          return false;
+        },
+        'this is a validate message',
+      ],
+    },
+
+    billingAddress: {
+      street: { type: String, index: true },
+      state: { type: String, index: true, enum: ['FL', 'MA', 'NY'] },
+      country: { type: String, index: true },
+    },
+
     skills: {
       type: [String],
       default: [],
@@ -123,6 +140,7 @@ const UserSchema: SchemaType<any> = new Schema(
 );
 
 UserSchema.set('autoIndex', false);
+UserSchema.index({ name: 1, age: -1 });
 UserSchema.index({ name: 1, age: -1 });
 
 // eslint-disable-next-line

--- a/src/__tests__/integration-test.js
+++ b/src/__tests__/integration-test.js
@@ -48,12 +48,7 @@ describe('integration tests', () => {
 
     it('should return subdocument if it is non-empty', async () => {
       const UserTC = composeWithMongoose(UserModel);
-      // UserTC.get('$findById.subDoc').extendField('field2', {
-      //   resolve: (source) => {
-      //     console.log('$findById.subDoc.field2 source:', source)
-      //     return source.field2;
-      //   }
-      // })
+
       schemaComposer.Query.addFields({
         user: UserTC.getResolver('findById'),
       });

--- a/src/discriminators/utils/__tests__/mergeCustomizationOptions-test.js
+++ b/src/discriminators/utils/__tests__/mergeCustomizationOptions-test.js
@@ -159,10 +159,12 @@ describe('mergeCustomizationOptions()', () => {
         skip: false,
         filter: {
           isRequired: true,
-          removeFields: ['id', 'dob'],
           operators: {
             one: ['gt', 'gte', 'lt'],
             two: ['gt', 'gte', 'lt', 'in[]', 'nin[]'],
+            four: {
+              foo: ['lte'],
+            },
           },
         },
       },
@@ -188,11 +190,13 @@ describe('mergeCustomizationOptions()', () => {
         sort: false,
         // skip: false,
         filter: {
-          removeFields: ['gender', 'dob', 'age'],
           operators: {
             one: ['gt', 'lte', 'ne', 'in[]', 'nin[]'],
             two: ['gt', 'gte', 'lt', 'lte', 'ne'],
             three: ['gte', 'lt'],
+            four: {
+              foo: ['gte', 'in[]'],
+            },
           },
         },
       },
@@ -224,11 +228,13 @@ describe('mergeCustomizationOptions()', () => {
         skip: false,
         filter: {
           isRequired: true,
-          removeFields: ['id', 'dob', 'gender', 'age'],
           operators: {
             one: ['gt', 'gte', 'lt', 'lte', 'ne', 'in[]', 'nin[]'],
             two: ['gt', 'gte', 'lt', 'in[]', 'nin[]', 'lte', 'ne'],
             three: ['gte', 'lt'],
+            four: {
+              foo: ['gte', 'lte', 'in[]'],
+            },
           },
         },
       },
@@ -252,7 +258,8 @@ describe('mergeCustomizationOptions()', () => {
     expect(mergeCustomizationOptions({}, childCustomOptions)).toEqual(childCustomOptions);
   });
 
-  it('should merge customisation Options', () => {
+  it('should merge customization options', () => {
+    // FIXME: mergeCustomizationOptions does not operate recursivly
     expect(mergeCustomizationOptions(baseCustomOptions, childCustomOptions)).toEqual(expected);
   });
 

--- a/src/discriminators/utils/__tests__/mergeTypeConverterResolverOpts-test.js
+++ b/src/discriminators/utils/__tests__/mergeTypeConverterResolverOpts-test.js
@@ -15,7 +15,7 @@ const baseConverterResolverOpts: TypeConverterResolversOpts = {
     skip: false,
     filter: {
       isRequired: true,
-      removeFields: ['id', 'dob'],
+      // removeFields: ['id', 'dob'],
       operators: {
         one: ['gt', 'gte', 'lt'],
         two: ['gt', 'gte', 'lt', 'in[]', 'nin[]'],
@@ -41,7 +41,7 @@ const childConverterResolverOpts: TypeConverterResolversOpts = {
     sort: false,
     // skip: false,
     filter: {
-      removeFields: ['gender', 'dob', 'age'],
+      // removeFields: ['gender', 'dob', 'age'],
       operators: {
         one: ['gt', 'lte', 'ne', 'in[]', 'nin[]'],
         two: ['gt', 'gte', 'lt', 'lte', 'ne'],
@@ -68,7 +68,7 @@ const expectedConverterResolverOpts: TypeConverterResolversOpts = {
     skip: false,
     filter: {
       isRequired: true,
-      removeFields: ['id', 'dob', 'gender', 'age'],
+      // removeFields: ['id', 'dob', 'gender', 'age'],
       operators: {
         one: ['gt', 'gte', 'lt', 'lte', 'ne', 'in[]', 'nin[]'],
         two: ['gt', 'gte', 'lt', 'in[]', 'nin[]', 'lte', 'ne'],

--- a/src/discriminators/utils/mergeCustomizationOptions.js
+++ b/src/discriminators/utils/mergeCustomizationOptions.js
@@ -98,7 +98,7 @@ export function mergeCustomizationOptions<TContext>(
   }
 
   // use base schemaComposer
-  mergedOptions.schemaComposer = baseCOptions.schemaComposer;
+  if (baseCOptions.schemaComposer) mergedOptions.schemaComposer = baseCOptions.schemaComposer;
 
   // merge fields map
   if (baseCOptions.fields) {

--- a/src/resolvers/__tests__/createOne-test.js
+++ b/src/resolvers/__tests__/createOne-test.js
@@ -89,6 +89,27 @@ describe('createOne() ->', () => {
       expect(result.record.id).toBe(result.recordId);
     });
 
+    it('should return payload.errors', async () => {
+      const result = await createOne(UserModel, UserTC).resolve({
+        args: {
+          record: { valid: 'AlwaysFails' },
+        },
+      });
+      expect(result.errors).toEqual([
+        { messages: ['Path `n` is required.'], path: 'n' },
+        { messages: ['this is a validate message'], path: 'valid' },
+      ]);
+    });
+
+    it('should return empty payload.errors', async () => {
+      const result = await createOne(UserModel, UserTC).resolve({
+        args: {
+          record: { n: 'foo' },
+        },
+      });
+      expect(result.errors).toEqual(null);
+    });
+
     it('should return mongoose document', async () => {
       const result = await createOne(UserModel, UserTC).resolve({
         args: { record: { name: 'NewUser' } },

--- a/src/resolvers/__tests__/updateById-test.js
+++ b/src/resolvers/__tests__/updateById-test.js
@@ -98,6 +98,24 @@ describe('updateById() ->', () => {
       expect(result.recordId).toBe(user1.id);
     });
 
+    it('should return empty payload.errors', async () => {
+      const result = await updateById(UserModel, UserTC).resolve({
+        args: {
+          record: { _id: user1.id, name: 'some name' },
+        },
+      });
+      expect(result.errors).toEqual(null);
+    });
+
+    it('should return payload.errors', async () => {
+      const result = await updateById(UserModel, UserTC).resolve({
+        args: {
+          record: { _id: user1.id, name: 'some name', valid: 'AlwaysFails' },
+        },
+      });
+      expect(result.errors).toEqual([{ messages: ['this is a validate message'], path: 'valid' }]);
+    });
+
     it('should change data via args.record in model', async () => {
       const result = await updateById(UserModel, UserTC).resolve({
         args: {

--- a/src/resolvers/__tests__/updateOne-test.js
+++ b/src/resolvers/__tests__/updateOne-test.js
@@ -125,6 +125,24 @@ describe('updateOne() ->', () => {
       expect(result.record.id).toBe(user1.id);
     });
 
+    it('should return empty payload.errors', async () => {
+      const result = await updateOne(UserModel, UserTC).resolve({
+        args: { filter: { _id: user1.id } },
+      });
+      expect(result.errors).toEqual(null);
+    });
+
+    it('should return payload.errors', async () => {
+      const result = await updateOne(UserModel, UserTC).resolve({
+        args: {
+          filter: { _id: user1.id },
+          record: { valid: 'AlwaysFails' },
+        },
+      });
+
+      expect(result.errors).toEqual([{ messages: ['this is a validate message'], path: 'valid' }]);
+    });
+
     it('should skip records', async () => {
       const result1 = await updateOne(UserModel, UserTC).resolve({
         args: {

--- a/src/resolvers/helpers/__tests__/filter-test.js
+++ b/src/resolvers/helpers/__tests__/filter-test.js
@@ -50,6 +50,7 @@ describe('Resolver helper `filter` ->', () => {
       expect(args.filter.type).toBeInstanceOf(InputTypeComposer);
     });
 
+    // TODO: use _operators[_id][in] ? why have _ids in root?
     it('should return filter with field _ids', () => {
       const args: any = filterHelperArgs(UserTC, UserModel, {
         filterTypeName: 'FilterUserType',

--- a/src/resolvers/helpers/__tests__/filterOperators-test.js
+++ b/src/resolvers/helpers/__tests__/filterOperators-test.js
@@ -1,6 +1,8 @@
 /* @flow */
-
+import mongoose from 'mongoose';
 import { schemaComposer, InputTypeComposer } from 'graphql-compose';
+import { composeWithMongoose } from '../../../composeWithMongoose';
+
 import {
   _createOperatorsField,
   addFilterOperators,
@@ -11,9 +13,18 @@ import { toMongoFilterDottedObject } from '../../../utils/toMongoDottedObject';
 import { UserModel } from '../../../__mocks__/userModel';
 
 let itc: InputTypeComposer<any>;
+let addressItc: InputTypeComposer<any>;
 
 beforeEach(() => {
   schemaComposer.clear();
+  addressItc = schemaComposer.createInputTC({
+    name: 'BillingAddressUserFieldInput',
+    fields: {
+      street: 'String',
+      state: 'String',
+      country: 'String',
+    },
+  });
   itc = schemaComposer.createInputTC({
     name: 'UserFilterInput',
     fields: {
@@ -22,6 +33,7 @@ beforeEach(() => {
       name: 'String',
       age: 'Int',
       skills: ['String'],
+      billingAddress: 'BillingAddressUserFieldInput',
     },
   });
 });
@@ -33,29 +45,53 @@ describe('Resolver helper `filter` ->', () => {
       expect(itc.hasField(OPERATORS_FIELDNAME)).toBe(true);
       expect(itc.getFieldTC(OPERATORS_FIELDNAME).getTypeName()).toBe('OperatorsTypeName');
     });
-
-    it('should by default have only indexed fields', () => {
-      _createOperatorsField(itc, 'OperatorsTypeName', UserModel, {});
-      const operatorsTC = itc.getFieldITC(OPERATORS_FIELDNAME);
-      expect(operatorsTC.getFieldNames()).toEqual(
-        expect.arrayContaining(['name', '_id', 'employment'])
-      );
-      expect(operatorsTC.hasField('age')).toBe(false);
-    });
-
     it('should have only provided fields via options', () => {
-      _createOperatorsField(itc, 'OperatorsTypeName', UserModel, { age: ['lt'] });
+      _createOperatorsField(itc, 'OperatorsTypeName', UserModel, { operators: { age: ['lt'] } });
       const operatorsTC = itc.getFieldITC(OPERATORS_FIELDNAME);
       expect(operatorsTC.hasField('age')).toBe(true);
     });
-
     it('should have only provided operators via options for field', () => {
-      _createOperatorsField(itc, 'OperatorsTypeName', UserModel, { age: ['lt', 'gte'] });
+      _createOperatorsField(itc, 'OperatorsTypeName', UserModel, {
+        operators: { age: ['lt', 'gte'] },
+      });
       const operatorsTC = itc.getFieldITC(OPERATORS_FIELDNAME);
       const ageTC = operatorsTC.getFieldITC('age');
       expect(ageTC.getFieldNames()).toEqual(expect.arrayContaining(['lt', 'gte']));
     });
+    it('should have recurse schema', () => {
+      _createOperatorsField(itc, 'OperatorsTypeName', UserModel, {
+        operators: {
+          age: ['lt', 'gte'],
+          billingAddress: { country: ['in[]'], state: ['in'] },
+        },
+      });
+      const operatorsTC = itc.getFieldITC(OPERATORS_FIELDNAME);
+      const billingAddressTC = operatorsTC.getFieldITC('billingAddress');
 
+      expect(billingAddressTC.getFieldNames()).toEqual(expect.arrayContaining(['country']));
+      const countryBillingAddressTC = billingAddressTC.getFieldITC('country');
+
+      expect(countryBillingAddressTC.getFieldNames()).toEqual(expect.arrayContaining(['in']));
+
+      expect(billingAddressTC.getFieldNames()).toEqual(expect.arrayContaining(['state']));
+      const stateBillingAddressTC = billingAddressTC.getFieldITC('state');
+      expect(stateBillingAddressTC.getFieldNames()).toEqual(expect.arrayContaining(['in']));
+    });
+
+    it('should not recurse on circular schemas to avoid maximum call stack size exceeded', () => {
+      const PersonSchema = new mongoose.Schema({
+        name: String,
+      });
+      PersonSchema.add({
+        spouse: PersonSchema,
+        friends: [PersonSchema],
+      });
+      const PersonModel = mongoose.model('Person', PersonSchema);
+      const tc = composeWithMongoose(PersonModel);
+      expect(tc.getFieldNames()).toEqual(
+        expect.arrayContaining(['_id', 'name', 'spouse', 'friends'])
+      );
+    });
     it('should reuse existed operatorsType', () => {
       const existedITC = itc.schemaComposer.getOrCreateITC('ExistedType');
       _createOperatorsField(itc, 'ExistedType', UserModel, {});
@@ -69,19 +105,41 @@ describe('Resolver helper `filter` ->', () => {
       expect(itc.hasField(OPERATORS_FIELDNAME)).toBe(true);
       expect(itc.getFieldTC(OPERATORS_FIELDNAME).getTypeName()).toBe('Operators');
     });
-
     it('should add OR field', () => {
       addFilterOperators(itc, UserModel, {});
       const fields = itc.getFieldNames();
       expect(fields).toEqual(expect.arrayContaining(['OR', 'name', 'age']));
       expect(itc.getFieldTC('OR').getType()).toBe(itc.getType());
     });
-
     it('should add AND field', () => {
       addFilterOperators(itc, UserModel, {});
       const fields = itc.getFieldNames();
       expect(fields).toEqual(expect.arrayContaining(['AND', 'name', 'age']));
       expect(itc.getFieldTC('AND').getType()).toBe(itc.getType());
+    });
+    it('should respect operators configuration', () => {
+      // onlyIndexed: false by default
+      addFilterOperators(itc, UserModel, { operators: { name: ['exists'] } });
+      const fields = itc.getFieldNames();
+      expect(fields).toEqual(expect.arrayContaining(['name']));
+      expect(itc.hasField('_operators')).toBe(true);
+      expect(itc.getFieldTC('_operators').getFieldNames()).toEqual(['name']);
+      expect(itc.getFieldTC('_operators').getFieldTC('name').getFieldNames()).toEqual(['exists']);
+    });
+    it('should respect operators configuration and allow onlyIndex', () => {
+      addFilterOperators(itc, UserModel, { onlyIndexed: true, operators: { name: ['exists'] } });
+      const fields = itc.getFieldNames();
+      expect(fields).toEqual(expect.arrayContaining(['name']));
+      expect(itc.hasField('_operators')).toBe(true);
+      expect(itc.getFieldTC('_operators').getFieldNames()).toEqual([
+        '_id',
+        'employment',
+        'name',
+        'age',
+        'skills',
+        'billingAddress',
+      ]);
+      expect(itc.getFieldTC('_operators').getFieldTC('name').getFieldNames()).toEqual(['exists']);
     });
   });
 
@@ -92,7 +150,18 @@ describe('Resolver helper `filter` ->', () => {
       };
       expect(processFilterOperators(filter)).toEqual({ age: { $gt: 10, $lt: 20 } });
     });
-
+    it('should process nested fields', () => {
+      const filter = {
+        [OPERATORS_FIELDNAME]: {
+          age: { gt: 10, lt: 20 },
+          address: { country: { in: ['US'] } },
+        },
+      };
+      expect(processFilterOperators(filter)).toEqual({
+        age: { $gt: 10, $lt: 20 },
+        address: { country: { $in: ['US'] } },
+      });
+    });
     it('should convert OR query', () => {
       const filter = {
         OR: [
@@ -116,7 +185,6 @@ describe('Resolver helper `filter` ->', () => {
         ],
       });
     });
-
     it('should convert AND query', () => {
       const filter = {
         AND: [
@@ -139,7 +207,6 @@ describe('Resolver helper `filter` ->', () => {
         ],
       });
     });
-
     it('should convert nested AND/OR query', () => {
       const filter = {
         OR: [

--- a/src/resolvers/helpers/filter.d.ts
+++ b/src/resolvers/helpers/filter.d.ts
@@ -2,21 +2,18 @@ import { ObjectTypeComposerArgumentConfigMapDefinition, ObjectTypeComposer } fro
 import { Model } from 'mongoose';
 import { MongoId } from '../../types/mongoid';
 import { ExtendedResolveParams } from '../index';
-import { FilterOperatorsArgs, FilterOperatorsOpts } from './filterOperators';
+import { FilterOperatorsArgs } from './filterOperators';
+
 
 export type FilterHelperArgsOpts = {
   filterTypeName?: string;
   isRequired?: boolean;
   onlyIndexed?: boolean;
-  requiredFields?: string | string[];
-  operators?: FilterOperatorsOpts | false;
-  removeFields?: string | string[];
+  operators?: any;
 };
 
 export type FilterHelperArgs<TSource = any, IndexedFieldsMap = { _id: MongoId }> = TSource &
-  FilterOperatorsArgs<TSource, IndexedFieldsMap> & {
-    _ids: MongoId[];
-  };
+  FilterOperatorsArgs<TSource, IndexedFieldsMap>
 
 export function getFilterHelperArgOptsMap(): Partial<
   Record<keyof FilterHelperArgsOpts, string | string[]>

--- a/src/resolvers/helpers/filterOperators.d.ts
+++ b/src/resolvers/helpers/filterOperators.d.ts
@@ -40,10 +40,6 @@ export type FilterOperatorsArgs<TSource, IndexedFieldsMap> = {
   AND: FilterHelperArgs<TSource>;
 };
 
-export type FilterOperatorsOpts = {
-  [fieldName: string]: FilterOperatorNames[] | false;
-};
-
 export function addFilterOperators(
   itc: InputTypeComposer,
   model: Model<any>,

--- a/src/resolvers/helpers/filterOperators.js
+++ b/src/resolvers/helpers/filterOperators.js
@@ -1,33 +1,68 @@
 /* @flow */
 /* eslint-disable no-use-before-define */
 
-import { getNamedType, type GraphQLInputType } from 'graphql-compose/lib/graphql';
-import type { MongooseModel } from 'mongoose';
-import type { InputTypeComposer } from 'graphql-compose';
+import {
+  getNamedType,
+  type GraphQLInputType,
+  SchemaMetaFieldDef,
+  GraphQLInputObjectType,
+  GraphQLScalarType,
+  GraphQLEnumType,
+} from 'graphql-compose/lib/graphql';
+import type { MongooseModel, Schema } from 'mongoose';
+import { InputTypeComposer, camelCase } from 'graphql-compose';
+import { isGetAccessor } from 'typescript';
 import { upperFirst, getIndexedFieldNamesForGraphQL } from '../../utils';
 import type { FilterHelperArgsOpts } from './filter';
 
-export type FilterOperatorNames = 'gt' | 'gte' | 'lt' | 'lte' | 'ne' | 'in[]' | 'nin[]';
-const availableOperators: FilterOperatorNames[] = ['gt', 'gte', 'lt', 'lte', 'ne', 'in[]', 'nin[]'];
+export type FilterOperatorNames =
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'ne'
+  | 'in[]'
+  | 'nin[]'
+  | 'regex'
+  | 'exists';
+const availableOperators: FilterOperatorNames[] = [
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'ne',
+  'in[]',
+  'nin[]',
+  'regex',
+  'exists',
+];
 
 export const OPERATORS_FIELDNAME = '_operators';
 
-export type FilterOperatorsOpts = {
-  [fieldName: string]: FilterOperatorNames[] | false,
-};
+export function _createRegexInput(itc: InputTypeComposer<any>) {
+  const regexITC = itc.schemaComposer.getOrCreateITC(`${OPERATORS_FIELDNAME}RegexInput`, (tc) => {
+    tc.addFields({
+      match: {
+        name: `${OPERATORS_FIELDNAME}RegexStringInput`,
+        type: 'String!',
+      },
+      options: {
+        name: `${OPERATORS_FIELDNAME}RegexOptionsInput`,
+        type: 'String',
+      },
+    });
+  });
+}
 
 export function addFilterOperators(
   itc: InputTypeComposer<any>,
   model: MongooseModel,
   opts: FilterHelperArgsOpts
 ) {
+  _createRegexInput(itc);
+
   if (!{}.hasOwnProperty.call(opts, 'operators') || opts.operators !== false) {
-    _createOperatorsField(
-      itc,
-      `Operators${opts.filterTypeName || ''}`,
-      model,
-      opts.operators || {}
-    );
+    _createOperatorsField(itc, `Operators${opts.filterTypeName || ''}`, model, opts);
   }
 
   itc.addFields({
@@ -36,31 +71,223 @@ export function addFilterOperators(
   });
 }
 
+export function _availableOperatorsFields(
+  fieldName: String,
+  itc: InputTypeComposer,
+  opts: FilterHelperArgsOpts,
+  operatorsConfig: any
+) {
+  const fields = [];
+
+  const operators = Array.isArray(operatorsConfig)
+    ? operatorsConfig.filter(
+        (value) => availableOperators.includes(value) || availableOperators.includes(`${value}[]`)
+      )
+    : availableOperators;
+
+  operators.forEach((operatorName) => {
+    const fc = itc.getFieldConfig(fieldName);
+    // unwrap from GraphQLNonNull and GraphQLList, if present
+    let namedType: GraphQLInputType = (getNamedType(fc.type): any);
+
+    // just treat enums as strings
+    if (namedType instanceof GraphQLEnumType) {
+      namedType = 'String';
+    }
+
+    if (namedType) {
+      if (['in', 'nin', 'in[]', 'nin[]'].includes(operatorName)) {
+        // wrap with GraphQLList, if operator required this with `[]`
+        const newName = operatorName.slice(-2) === '[]' ? operatorName.slice(0, -2) : operatorName;
+        fields[newName] = {
+          ...fc,
+          type: [namedType],
+        };
+      } else {
+        if (operatorName === 'exists') {
+          namedType = 'Boolean';
+        } else if (operatorName === 'regex') {
+          namedType = itc.schemaComposer.getITC(`${OPERATORS_FIELDNAME}RegexInput`);
+        }
+        fields[operatorName] = {
+          ...fc,
+          type: namedType,
+        };
+      }
+    }
+  });
+  return fields;
+}
+
+export function _recurseSchema(
+  inputITC: InputTypeComposer,
+  sourceITC: InputTypeComposer,
+  typeName: String,
+  pathName?: String,
+  schema: Schema,
+  opts: FilterHelperArgsOpts,
+  operators: any
+) {
+  const { schemaComposer } = sourceITC;
+
+  const sourceType = sourceITC.getType();
+
+  if (sourceType instanceof GraphQLInputObjectType) {
+    Object.keys(sourceITC.getFields()).forEach((fieldName) => {
+      const field = sourceITC.getField(fieldName);
+      const fieldTC = sourceITC.getFieldTC(fieldName);
+      const fieldType = fieldTC.getType();
+
+      // alias
+      const fullPath = pathName ? `${pathName}.${fieldName}` : fieldName;
+      let schemaType;
+      if (schema) {
+        if (schema.pathType) {
+          const pathType = schema.pathType(fullPath);
+          schemaType = schema.path(fullPath);
+          if (pathType === 'virtual') schemaType = schema.virtualpath(fullPath);
+          if (pathType === 'nested') schemaType = null;
+        } else if (typeof schema.path === 'string') {
+          schemaType = null; // array?
+        }
+      }
+      const isIndexed = schemaType?.options?.index || fieldName === '_id';
+      const isRequired = schemaType?.options?.required;
+
+      const hasOperatorsConfig =
+        opts.operators &&
+        operators &&
+        operators[fieldName] &&
+        Object.keys(operators[fieldName]).length >= 1;
+      const operatorsConfig = hasOperatorsConfig ? operators[fieldName] : undefined;
+
+      // prevent infinite recursion
+      if (sourceType === fieldType) return;
+
+      if (fieldType instanceof GraphQLScalarType) {
+        const newITC = schemaComposer.createInputTC({
+          name: `${fieldName}${typeName}`,
+          type: isRequired ? fieldTC.getTypeNonNull() : fieldType,
+        });
+
+        if (
+          (opts.onlyIndexed && isIndexed) ||
+          !!opts.onlyIndexed ||
+          hasOperatorsConfig ||
+          !opts.operators
+        ) {
+          newITC.addFields(_availableOperatorsFields(fieldName, sourceITC, opts, operatorsConfig));
+          inputITC.addFields({
+            [fieldName]: newITC,
+          });
+        }
+      } else if (fieldType instanceof GraphQLInputObjectType) {
+        const newITC = schemaComposer.createInputTC({
+          name: `${fieldName}${typeName}`,
+          type: fieldType,
+        });
+
+        _recurseSchema(
+          newITC,
+          fieldTC,
+          `${upperFirst(fieldName)}${typeName}`,
+          `${fieldName}`,
+          schemaType || schema,
+          opts,
+          operatorsConfig
+        );
+        if (
+          (opts.onlyIndexed && isIndexed) ||
+          !!opts.onlyIndexed ||
+          hasOperatorsConfig ||
+          !opts.operators
+        ) {
+          inputITC.addFields({
+            [fieldName]: newITC,
+          });
+        }
+      } else if (fieldType instanceof GraphQLEnumType) {
+        const newITC = schemaComposer.createInputTC({
+          name: `${fieldName}${typeName}`,
+          type: 'String',
+        });
+        if (
+          (opts.onlyIndexed && isIndexed) ||
+          !!opts.onlyIndexed ||
+          hasOperatorsConfig ||
+          !opts.operators
+        ) {
+          newITC.addFields(_availableOperatorsFields(fieldName, sourceITC, opts, operatorsConfig));
+          inputITC.addFields({
+            [fieldName]: newITC,
+          });
+        }
+      }
+    });
+  }
+}
+
+export function _createOperatorsField<TContext>(
+  itc: InputTypeComposer<TContext>,
+  typeName: string,
+  model: MongooseModel,
+  opts: FilterHelperArgsOpts
+): InputTypeComposer<TContext> {
+  _createRegexInput(itc);
+
+  const operatorsITC = itc.schemaComposer.getOrCreateITC(typeName, (tc) => {
+    tc.setDescription('For performance reason this type contains only *indexed* fields.');
+  });
+
+  _recurseSchema(operatorsITC, itc, typeName, null, model.schema, opts, opts.operators);
+
+  itc.setField(OPERATORS_FIELDNAME, {
+    type: operatorsITC,
+    description: 'List of *indexed* fields that can be filtered via operators.',
+  });
+
+  return operatorsITC;
+}
+
+export const _recurseFields = (fields: Object) => {
+  let selectors = {};
+  if (fields === Object(fields)) {
+    Object.keys(fields).forEach((fieldName) => {
+      if (availableOperators.includes(fieldName) || availableOperators.includes(`${fieldName}[]`)) {
+        let selection = fields[fieldName];
+        if (fieldName === 'regex') {
+          selection = new RegExp(fields[fieldName].match, fields[fieldName].options);
+        }
+        selectors[`$${fieldName}`] = selection;
+      } else {
+        selectors[fieldName] = _recurseFields(fields[fieldName]);
+      }
+    });
+  } else if (Array.isArray(fields)) {
+    Object.keys(fields).forEach((fieldName) => {
+      selectors[fieldName] = _recurseFields(fields[fieldName]);
+    });
+  } else {
+    selectors = fields;
+  }
+  return selectors;
+};
+
 export function processFilterOperators(filter: Object) {
   if (!filter) return filter;
+
   _prepareAndOrFilter(filter);
+
   if (filter[OPERATORS_FIELDNAME]) {
     const operatorFields = filter[OPERATORS_FIELDNAME];
     Object.keys(operatorFields).forEach((fieldName) => {
-      const fieldOperators = { ...operatorFields[fieldName] };
-      const criteria = {};
-      Object.keys(fieldOperators).forEach((operatorName) => {
-        if (Array.isArray(fieldOperators[operatorName])) {
-          criteria[`$${operatorName}`] = fieldOperators[operatorName].map((v) =>
-            processFilterOperators(v)
-          );
-        } else {
-          criteria[`$${operatorName}`] = processFilterOperators(fieldOperators[operatorName]);
-        }
-      });
-      if (Object.keys(criteria).length > 0) {
-        // eslint-disable-next-line
-        filter[fieldName] = criteria;
-      }
+      // eslint-disable-next-line no-param-reassign
+      filter[fieldName] = _recurseFields(operatorFields[fieldName]);
     });
     // eslint-disable-next-line no-param-reassign
     delete filter[OPERATORS_FIELDNAME];
   }
+
   return filter;
 }
 
@@ -87,73 +314,4 @@ export function _prepareAndOrFilter(filter: Object) {
     delete filter.AND;
   }
   /* eslint-enable no-param-reassign */
-}
-
-export function _createOperatorsField<TContext>(
-  itc: InputTypeComposer<TContext>,
-  typeName: string,
-  model: MongooseModel,
-  operatorsOpts: FilterOperatorsOpts
-): InputTypeComposer<TContext> {
-  const operatorsITC = itc.schemaComposer.getOrCreateITC(typeName, (tc) => {
-    tc.setDescription('For performance reason this type contains only *indexed* fields.');
-  });
-
-  // if `opts.resolvers.[resolverName].filter.operators` is empty and not disabled via `false`
-  // then fill it up with indexed fields
-  const indexedFields = getIndexedFieldNamesForGraphQL(model);
-  if (Object.keys(operatorsOpts).length === 0) {
-    indexedFields.forEach((fieldName) => {
-      operatorsOpts[fieldName] = availableOperators; // eslint-disable-line
-    });
-  }
-
-  itc.getFieldNames().forEach((fieldName) => {
-    if (operatorsOpts[fieldName] && operatorsOpts[fieldName] !== false) {
-      const fields = {};
-      let operators;
-      if (operatorsOpts[fieldName] && Array.isArray(operatorsOpts[fieldName])) {
-        operators = operatorsOpts[fieldName];
-      } else {
-        operators = availableOperators;
-      }
-      operators.forEach((operatorName) => {
-        const fc = itc.getFieldConfig(fieldName);
-        // unwrap from GraphQLNonNull and GraphQLList, if present
-        const namedType: GraphQLInputType = (getNamedType(fc.type): any);
-        if (namedType) {
-          if (operatorName.slice(-2) === '[]') {
-            // wrap with GraphQLList, if operator required this with `[]`
-            const newName = operatorName.slice(0, -2);
-            fields[newName] = {
-              ...fc,
-              type: [namedType],
-            };
-          } else {
-            fields[operatorName] = {
-              ...fc,
-              type: namedType,
-            };
-          }
-        }
-      });
-      if (Object.keys(fields).length > 0) {
-        const operatorTypeName = `${upperFirst(fieldName)}${typeName}`;
-        const operatorITC = itc.schemaComposer.getOrCreateITC(operatorTypeName, (tc) => {
-          tc.setFields((fields: any));
-        });
-        operatorsITC.setField(fieldName, operatorITC);
-      }
-    }
-  });
-
-  // add to main filterITC if was added some fields
-  if (operatorsITC.getFieldNames().length > 0) {
-    itc.setField(OPERATORS_FIELDNAME, {
-      type: operatorsITC,
-      description: 'List of *indexed* fields that can be filtered via operators.',
-    });
-  }
-
-  return operatorsITC;
 }

--- a/src/utils/getOrCreateErrorPayload.js
+++ b/src/utils/getOrCreateErrorPayload.js
@@ -1,0 +1,16 @@
+import type { ObjectTypeComposer } from 'graphql-compose';
+
+export function getOrCreateErrorPayload(tc: ObjectTypeComposer) {
+  return tc.schemaComposer.getOrCreateOTC('ErrorPayload', (t) => {
+    t.addFields({
+      path: {
+        type: 'String',
+        description: 'Source of error, typically a model validation path',
+      },
+      messages: {
+        type: '[String]',
+        description: 'Error messages',
+      },
+    });
+  });
+}


### PR DESCRIPTION
There's a lot to talk about here, such has:

- Support for recursive `_operators` /  filters
- Change behaviour from `onlyIndexed` to allow all fields (its up to the developer to use onlyIndexed or set the operators tree they'd like to allow)
- Adds Validation Errors in Payload (Yay, client side bonus)
- Adds exists and regex operators (Reasonable first pass implementations)

TODO:
- Payload errors for ...Many methods
- Broken test - `Resolver helper `filter` -> › filterHelperArgs() › should return filter with field _ids` do we really need `_ids` or is `_operators[_id][in]` well enough?
- Broken test - `mergeCustomizationOptions() › should merge customization options` support recursive option merging

Opening for discussion 

@nodkz 👍 

Please don't yell at me too much for causing a mess of things! I hope you like where I'm going with these changes.