### PR TITLE
Consider aliases from discriminators during preparation

### DIFF
--- a/src/resolvers/helpers/__tests__/aliases-test.ts
+++ b/src/resolvers/helpers/__tests__/aliases-test.ts
@@ -25,5 +25,43 @@ describe('Resolver helper `alises` ->', () => {
       const aliases = prepareAliases(User);
       expect(aliases).toEqual(false);
     });
+
+    it('should extract field aliases from discriminator Models', () => {
+      const UserSchema = new mongoose.Schema({
+        e: {
+          type: String,
+          alias: 'emailAddress',
+        },
+      });
+      const User = mongoose.model('User111', UserSchema);
+      const VIPUserSchema = new mongoose.Schema({
+        f: {
+          type: Number,
+          alias: 'freeDrinks',
+        },
+      });
+      User.discriminator('VIPUser111', VIPUserSchema);
+      const aliases = prepareAliases(User);
+      expect(aliases).toEqual({ emailAddress: 'e', freeDrinks: 'f' });
+    });
+
+    it('should extract field aliases in discriminator Models inherited from base Model', () => {
+      const UserSchema = new mongoose.Schema({
+        e: {
+          type: String,
+          alias: 'emailAddress',
+        },
+      });
+      const User = mongoose.model('User789', UserSchema);
+      const VIPUserSchema = new mongoose.Schema({
+        f: {
+          type: Number,
+          alias: 'freeDrinks',
+        },
+      });
+      const VIPUser = User.discriminator('VIPUser789', VIPUserSchema);
+      const aliases = prepareAliases(VIPUser);
+      expect(aliases).toEqual({ emailAddress: 'e', freeDrinks: 'f' });
+    });
   });
 });

--- a/src/resolvers/helpers/aliases.ts
+++ b/src/resolvers/helpers/aliases.ts
@@ -5,7 +5,14 @@ export type AliasesMap = {
 };
 
 export function prepareAliases(model: Model<any>): AliasesMap | false {
-  const aliases = (model?.schema as any)?.aliases;
+  const aliases = (model?.schema as any)?.aliases || {};
+
+  if (model.discriminators) {
+    Object.keys(model.discriminators).forEach((subModelName: string) => {
+      const submodel: Model<any> = (model.discriminators as any)[subModelName];
+      Object.assign(aliases, (submodel?.schema as any)?.aliases);
+    });
+  }
   if (Object.keys(aliases).length > 0) {
     return aliases;
   }


### PR DESCRIPTION
I have the following use case:

```js
const CarSchema = new Schema({ s: { type: Number, required: true, alias: "speed" } }, { discriminatorKey: 't' });
const Car = model('Car', CarSchema);

const TimeMachineSchema = new Schema({ f: { type: Number, required: true, alias: "fluxCompensatorVersion" } }, { discriminatorKey: 't' });
const TimeMachine = Car.discriminator('TimeMachine', TimeMachineSchema);

...

const CarDTC = composeWithMongooseDiscriminators(Car);

schemaComposer.Query.addFields({
  allCars: CarDTC.getResolver("findMany"),
});

...


gql`
{
  query FindAllCars() {
    allCars() {
      __typename
      speed

      ... on TimeMachine {
        fluxCompensatorVersion
      }
    }
  }
}
`
```

So we create a resolver from the base DTC which should be able to resolve all its discriminator documents.


The query does not work and errors with

```
Cannot return null for non-nullable field TimeMachine.fluxCompensatorVersion.
```

The reason is that in this example for `Car` the lib does not consider the aliases of all its discriminators, so it does not translate the alias for `TimeMachine` in this example.

Let me know what you think.