### PR TITLE
Adds allowAll option for filters which enables all operators regardle…

### DIFF
--- a/src/resolvers/helpers/filter.ts
+++ b/src/resolvers/helpers/filter.ts
@@ -18,6 +18,7 @@ export type FilterHelperArgsOpts = {
   baseTypeName?: string;
   isRequired?: boolean;
   onlyIndexed?: boolean;
+  allowAll?: boolean;
   requiredFields?: string | string[];
   operators?: FieldsOperatorsConfig | false;
   removeFields?: string | string[];

--- a/src/resolvers/helpers/filterOperators.ts
+++ b/src/resolvers/helpers/filterOperators.ts
@@ -45,6 +45,7 @@ export function addFilterOperators(
       baseTypeName: opts.baseTypeName || itc.getTypeName(),
       operators: opts.operators,
       onlyIndexed: opts.onlyIndexed || true,
+      allowAll: opts.allowAll || false,
       prefix: opts.prefix || '',
       suffix: `Operators${opts.suffix || ''}`,
     });
@@ -117,7 +118,7 @@ export function _recurseSchema(
       // operators are disabled for current field SO skip field addition
       return;
     }
-    if (opts.onlyIndexed && !isIndexed && !fieldOperatorsConfig) {
+    if (opts.onlyIndexed && !isIndexed && !fieldOperatorsConfig && !opts.allowAll) {
       // field does not have index & does not have manual config SO skip field addition
       return;
     }
@@ -184,6 +185,7 @@ interface CreateOperatorsFieldOpts {
   baseTypeName: string;
   operators?: FieldsOperatorsConfig;
   onlyIndexed?: boolean;
+  allowAll?: boolean;
   prefix?: string;
   suffix?: string;
 }


### PR DESCRIPTION
@nodkz something like this, re: #255 

> Thanks @nodkz, some feedback:
> 
> ccfb006#diff-5df9038cc258d9a4643e39deb8e85567R121
> 
> This should be an option, for example you may not want to index every field in your database (indexes come with a write cost) but would still like it query-able, without massive amounts of configuration. It's very much a large convenience. Especially for backend operations like an admin ui. The database I work with for example has massive schemas and relatively small numbers of records <300k and a sizeable DB has no problems cutting through that without indexes on everything. It's also really useful for prototyping.
> 
> I'll also have to check how this works with nested and virtuals: ccfb006#diff-5df9038cc258d9a4643e39deb8e85567L142
> 
> Again thanks for the work and getting it in!

Closing #255 and opening this.