### PR TITLE
Refactor `pagination` & `connection` resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,9 @@
   },
   "homepage": "https://github.com/graphql-compose/graphql-compose-mongoose",
   "dependencies": {
-    "dataloader": "^2.0.0"
-  },
-  "optionalDependencies": {
-    "graphql-compose-connection": "^7.0.0",
-    "graphql-compose-pagination": "^7.0.0"
+    "dataloader": "^2.0.0",
+    "graphql-compose-connection": "8.0.1",
+    "graphql-compose-pagination": "8.0.1"
   },
   "peerDependencies": {
     "graphql-compose": "^7.21.1",
@@ -40,17 +38,15 @@
     "@types/mongoose": "5.7.36",
     "@typescript-eslint/eslint-plugin": "4.1.0",
     "@typescript-eslint/parser": "4.1.0",
-    "eslint": "7.8.1",
+    "eslint": "7.9.0",
     "eslint-config-airbnb-base": "14.2.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-prettier": "3.1.4",
     "graphql": "15.3.0",
     "graphql-compose": "7.21.1",
-    "graphql-compose-connection": "^7.0.0",
-    "graphql-compose-pagination": "^7.0.0",
     "jest": "26.4.2",
-    "mongodb-memory-server": "6.7.4",
+    "mongodb-memory-server": "6.7.5",
     "mongoose": "5.10.5",
     "prettier": "2.1.1",
     "request": "2.88.2",

--- a/src/resolvers/__tests__/connection-test.ts
+++ b/src/resolvers/__tests__/connection-test.ts
@@ -148,15 +148,6 @@ describe('connection() resolver', () => {
       expect(resolver.getNestedName()).toEqual('connection');
     });
 
-    it('should return Resolver object with custom name', () => {
-      const resolver = connection(UserModel, UserTC, {
-        connectionResolverName: 'customConnection',
-      } as any);
-      if (!resolver) throw new Error('Connection resolver is undefined');
-      expect(resolver).toBeInstanceOf(Resolver);
-      expect(resolver.getNestedName()).toEqual('customConnection');
-    });
-
     it('Resolver object should have `filter` arg', () => {
       const resolver = connection(UserModel, UserTC);
       if (!resolver) throw new Error('Connection resolver is undefined');

--- a/src/resolvers/connection.ts
+++ b/src/resolvers/connection.ts
@@ -1,48 +1,27 @@
 import type { Document, Model } from 'mongoose';
-import type { ConnectionSortMapOpts as _ConnectionSortMapOpts } from 'graphql-compose-connection';
-import type {
-  Resolver,
-  ObjectTypeComposer,
-  ObjectTypeComposerFieldConfigMap,
-} from 'graphql-compose';
+import {
+  prepareConnectionResolver,
+  ConnectionResolverOpts as _ConnectionResolverOpts,
+  ConnectionTArgs,
+} from 'graphql-compose-connection';
+import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { CountResolverOpts, count } from './count';
+import { FindManyResolverOpts, findMany } from './findMany';
 import { getUniqueIndexes, extendByReversedIndexes, IndexT } from '../utils/getIndexesFromModel';
 
-export type ConnectionResolverOpts<TContext = any> = _ConnectionSortMapOpts & {
-  edgeFields?: ObjectTypeComposerFieldConfigMap<any, TContext>;
-  connectionResolverName?: string;
-  findResolverName?: string;
-  countResolverName?: string;
-  edgeTypeName?: string;
-};
-
-type TArgs = {
-  first?: number;
-  after?: string;
-  last?: number;
-  before?: string;
-  filter?: any;
-  sort?: Record<string, any>;
+export type ConnectionResolverOpts<TContext = any> = Omit<
+  _ConnectionResolverOpts<TContext>,
+  'countResolver' | 'findManyResolver'
+> & {
+  countOpts?: CountResolverOpts;
+  findManyOpts?: FindManyResolverOpts;
 };
 
 export function connection<TSource = any, TContext = any, TDoc extends Document = any>(
   model: Model<TDoc>,
   tc: ObjectTypeComposer<TDoc, TContext>,
   opts?: ConnectionResolverOpts<TContext>
-): Resolver<TSource, TContext, TArgs, TDoc> | undefined {
-  try {
-    require.resolve('graphql-compose-connection');
-  } catch (e) {
-    return undefined;
-  }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const prepareConnectionResolver = require('graphql-compose-connection').prepareConnectionResolver;
-
-  if (!prepareConnectionResolver) {
-    throw new Error(
-      'You should update `graphql-compose-connection` package till 3.2.0 version or above'
-    );
-  }
-
+): Resolver<TSource, TContext, ConnectionTArgs, TDoc> | undefined {
   const uniqueIndexes = extendByReversedIndexes(getUniqueIndexes(model), {
     reversedFirst: true,
   });
@@ -69,24 +48,14 @@ export function connection<TSource = any, TContext = any, TDoc extends Document 
       },
     };
   });
-  const {
-    connectionResolverName = 'connection',
-    findResolverName = 'findMany',
-    countResolverName = 'count',
-    edgeFields,
-    edgeTypeName,
-    ...sortOptions
-  } = opts || {};
-  return prepareConnectionResolver(tc, {
-    connectionResolverName,
-    findResolverName,
-    countResolverName,
-    sort: {
-      ...sortConfigs,
-      ...sortOptions,
-    },
-    edgeFields,
-    edgeTypeName,
+
+  const { findManyOpts, countOpts, ...restOpts } = opts || {};
+
+  return prepareConnectionResolver<any, any>(tc, {
+    findManyResolver: findMany(model, tc, findManyOpts),
+    countResolver: count(model, tc, countOpts),
+    sort: sortConfigs,
+    ...restOpts,
   });
 }
 

--- a/src/resolvers/pagination.ts
+++ b/src/resolvers/pagination.ts
@@ -1,41 +1,31 @@
 import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
+import {
+  preparePaginationResolver,
+  PaginationTArgs,
+  PaginationResolverOpts as _PaginationResolverOpts,
+} from 'graphql-compose-pagination';
+import { CountResolverOpts, count } from './count';
+import { FindManyResolverOpts, findMany } from './findMany';
 
-export type PaginationResolverOpts = {
-  perPage?: number;
-};
-
-type TArgs = {
-  page?: number;
-  perPage?: number;
-  filter?: any;
-  sort?: Record<string, any>;
+export type PaginationResolverOpts = Omit<
+  _PaginationResolverOpts,
+  'countResolver' | 'findManyResolver'
+> & {
+  countOpts?: CountResolverOpts;
+  findManyOpts?: FindManyResolverOpts;
 };
 
 export function pagination<TSource = any, TContext = any, TDoc extends Document = any>(
-  _model: Model<TDoc>,
+  model: Model<TDoc>,
   tc: ObjectTypeComposer<TDoc, TContext>,
   opts?: PaginationResolverOpts
-): Resolver<TSource, TContext, TArgs, TDoc> | undefined {
-  try {
-    require.resolve('graphql-compose-pagination');
-  } catch (e) {
-    return undefined;
-  }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const preparePaginationResolver = require('graphql-compose-pagination').preparePaginationResolver;
-
-  if (!preparePaginationResolver) {
-    throw new Error(
-      'You should update `graphql-compose-pagination` package till 3.3.0 version or above'
-    );
-  }
-
-  const resolver = preparePaginationResolver(tc, {
-    findResolverName: 'findMany',
-    countResolverName: 'count',
-    ...opts,
+): Resolver<TSource, TContext, PaginationTArgs, TDoc> {
+  const { countOpts, findManyOpts, ...restOpts } = opts || {};
+  const resolver = preparePaginationResolver<any, any>(tc, {
+    findManyResolver: findMany(model, tc, findManyOpts),
+    countResolver: count(model, tc, countOpts),
+    ...restOpts,
   });
-
   return resolver;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,10 +2513,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@7.8.1:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.8.1.tgz#e59de3573fb6a5be8ff526c791571646d124a8fa"
-  integrity sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==
+eslint@7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.9.0.tgz#522aeccc5c3a19017cf0cb46ebfd660a79acf337"
+  integrity sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.1.3"
@@ -3169,15 +3169,15 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-compose-connection@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/graphql-compose-connection/-/graphql-compose-connection-7.0.1.tgz#fd7be1e4dfa0b42e8aa22335bef4d9679d87a6fb"
-  integrity sha512-RYk1MkH5KisSWJCjk7AClI1y8qvkTYvEC5QnZdgduku0uqiEkwDSXz4lgGVfua6v/y/h/SHtxnna/nu/ZocyTg==
+graphql-compose-connection@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/graphql-compose-connection/-/graphql-compose-connection-8.0.1.tgz#6416ead781108a6628c542908f43cf89d3200222"
+  integrity sha512-VBEdtzEp862TlV/uf7GDVYI0wwfTQAQlDXIZVl9IlYO5BcDD94kaPcrTuzQ/j991G09vx2ebqLu2zRI3uLZ7kg==
 
-graphql-compose-pagination@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/graphql-compose-pagination/-/graphql-compose-pagination-7.0.0.tgz#81edf2327416d10f237a3f1ff67990899a37b017"
-  integrity sha512-Rak7Dmkb5U4Kio+FgWSucVFho2xxRyCI+kNcZWhxJRVfZusw+VuhjkvxPUiKTiFEb+DtTrXUeetWT24plcC0fg==
+graphql-compose-pagination@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/graphql-compose-pagination/-/graphql-compose-pagination-8.0.1.tgz#785c4c83dec5c81dee7ce5baee71cdf5b7a55240"
+  integrity sha512-DxFVSFS9fuDdVOCUz6sr8r1wwwFytUUQ6a2ihQAEdXx7a7p3ZC797RWHdprnnKtLPrioHIIWPCbIoyn4c4kVgQ==
 
 graphql-compose@7.21.1:
   version "7.21.1"
@@ -5038,10 +5038,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-mongodb-memory-server-core@6.7.4:
-  version "6.7.4"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.4.tgz#5870e92451433d5d47ed4510e97dca8b7507786b"
-  integrity sha512-jvlx5+OUpJOagSyQXHHH/HhT63cJtdN5yruvSrjQ5Ivfq1lITI7fq6vTxZe4USlGoygqQiJN+MX8b1JYX2sLnw==
+mongodb-memory-server-core@6.7.5:
+  version "6.7.5"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.5.tgz#f3fd1e517e8f798af8a93bb1d37a6cd0b04e7427"
+  integrity sha512-G4Wv1MAQg5B/aXpRwD5jy6Ubspcd7w4LsFl+rYJHhUgj8VMZGa4hX1pcEW26ghaw7gm24YsyXwDezHZPtxijKA==
   dependencies:
     "@types/tmp" "^0.2.0"
     camelcase "^6.0.0"
@@ -5062,12 +5062,12 @@ mongodb-memory-server-core@6.7.4:
   optionalDependencies:
     mongodb "3.6.2"
 
-mongodb-memory-server@6.7.4:
-  version "6.7.4"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-6.7.4.tgz#d34edbbd0fc8c9728260d4ae9d5178feab5f30df"
-  integrity sha512-VucLjrv6PBzmz36KlReBv62uPg4JkAywHvDHUXO/LXtAroWcH7HjECbCSTlwJIhGwpWcoeuZstlsrgu2btsn7A==
+mongodb-memory-server@6.7.5:
+  version "6.7.5"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-6.7.5.tgz#3eb4033bba56bd1822b73f581e0badc12af05401"
+  integrity sha512-Ws4IRrFqCEoD27jzFHfST9lXyrgDddpLXcoQ7B0S4Sc5v3N5tpchmvueuZ0BMj4bwwBJlWl64nXNgCoooYvupw==
   dependencies:
-    mongodb-memory-server-core "6.7.4"
+    mongodb-memory-server-core "6.7.5"
 
 mongodb@3.6.2:
   version "3.6.2"


### PR DESCRIPTION
Use them as `dependencies` (not `peerDependencies`)
Refactor code using `count` & `findMany` resolvers as instances (not `getResolver('count')`, `getResolver('findMany')`)
Improve type defs.