### PR TITLE
Copy relations to child type composers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "lib"
   ],
   "main": "lib/index.js",
-  "module": "mjs/index.mjs",
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
@@ -30,7 +29,7 @@
     "graphql-compose-pagination": "^7.0.0"
   },
   "peerDependencies": {
-    "graphql-compose": "^7.1.0",
+    "graphql-compose": "^7.21.4",
     "mongoose": "^5.0.0 || ^4.4.0"
   },
   "devDependencies": {
@@ -45,7 +44,7 @@
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-prettier": "3.1.4",
     "graphql": "15.3.0",
-    "graphql-compose": "7.19.4",
+    "graphql-compose": "7.21.4",
     "graphql-compose-connection": "^6.2.0",
     "graphql-compose-pagination": "^6.1.0",
     "jest": "26.4.1",

--- a/src/discriminators/__tests__/composeChildTC-test.ts
+++ b/src/discriminators/__tests__/composeChildTC-test.ts
@@ -8,6 +8,15 @@ beforeAll(() => schemaComposer.clear());
 
 describe('composeChildTC ->', () => {
   const CharacterDTC = composeWithMongooseDiscriminators(CharacterModel);
+  CharacterDTC.addRelation('friends', {
+    resolver: () => CharacterDTC.getResolver('findById'),
+    prepareArgs: {
+      _id: (source) => source.friends,
+    },
+    projection: { friends: 1 },
+  });
+  CharacterDTC.extendField('friends', { type: '[String!]' });
+
   const PersonTC = CharacterDTC.discriminator(PersonModel);
   const DroidTC = CharacterDTC.discriminator(DroidModel);
 
@@ -19,6 +28,16 @@ describe('composeChildTC ->', () => {
   it('should copy all baseFields from BaseDTC to ChildTCs', () => {
     expect(DroidTC.getFieldNames()).toEqual(expect.arrayContaining(CharacterDTC.getFieldNames()));
     expect(PersonTC.getFieldNames()).toEqual(expect.arrayContaining(CharacterDTC.getFieldNames()));
+  });
+
+  it('should copy all relations from BaseDTC to ChildTCs', () => {
+    expect(DroidTC.getRelations()).toEqual(CharacterDTC.getRelations());
+    expect(PersonTC.getRelations()).toEqual(CharacterDTC.getRelations());
+  });
+
+  it('should copy the extended Field from BaseDTC to ChildTCs', () => {
+    expect(DroidTC.getField('friends').type).toEqual(CharacterDTC.getField('friends').type);
+    expect(PersonTC.getField('friends').type).toEqual(CharacterDTC.getField('friends').type);
   });
 
   it('should make childTC have same fieldTypes as baseTC', () => {

--- a/src/discriminators/composeChildTC.ts
+++ b/src/discriminators/composeChildTC.ts
@@ -6,6 +6,22 @@ import type {
 import { prepareChildResolvers } from './prepareChildResolvers';
 import { reorderFields } from './utils/reorderFields';
 
+function copyBaseTcRelationsToChildTc(
+  baseDTC: ObjectTypeComposer<any, any>,
+  childTC: ObjectTypeComposer<any, any>
+) {
+  const relations = baseDTC.getRelations();
+  const childRelations = childTC.getRelations();
+  Object.keys(relations).forEach((name) => {
+    if (childRelations[name]) {
+      return;
+    }
+    childTC.addRelation(name, relations[name] as any);
+  });
+
+  return childTC;
+}
+
 // copy all baseTypeComposer fields to childTC
 // these are the fields before calling discriminator
 function copyBaseTCFieldsToChildTC(
@@ -35,7 +51,8 @@ export function composeChildTC<TSource, TContext>(
   childTC: ObjectTypeComposer<TSource, TContext>,
   opts: ComposeWithMongooseDiscriminatorsOpts<TContext>
 ): ObjectTypeComposer<TSource, TContext> {
-  const composedChildTC = copyBaseTCFieldsToChildTC(baseDTC, childTC);
+  let composedChildTC = copyBaseTcRelationsToChildTc(baseDTC, childTC);
+  composedChildTC = copyBaseTCFieldsToChildTC(baseDTC, composedChildTC);
 
   composedChildTC.addInterface(baseDTC.getDInterface());
 

--- a/src/discriminators/composeChildTC.ts
+++ b/src/discriminators/composeChildTC.ts
@@ -16,7 +16,7 @@ function copyBaseTcRelationsToChildTc(
     if (childRelations[name]) {
       return;
     }
-    childTC.addRelation(name, relations[name] as any);
+    childTC.addRelation(name, relations[name]);
   });
 
   return childTC;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,10 +3195,10 @@ graphql-compose-pagination@^7.0.0:
   resolved "https://registry.yarnpkg.com/graphql-compose-pagination/-/graphql-compose-pagination-7.0.0.tgz#81edf2327416d10f237a3f1ff67990899a37b017"
   integrity sha512-Rak7Dmkb5U4Kio+FgWSucVFho2xxRyCI+kNcZWhxJRVfZusw+VuhjkvxPUiKTiFEb+DtTrXUeetWT24plcC0fg==
 
-graphql-compose@7.19.4:
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-7.19.4.tgz#bda521055a45bafb646754c078d2c97fdc08dd6e"
-  integrity sha512-j+n/3j19X83s/8JQCE3GSk+py7/7gHciqDdECD3p33x99UQmxmgcsqsIV1QyEdaJqq0SoCPjwCSzjXvEjkpiWw==
+graphql-compose@7.21.4:
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-7.21.4.tgz#5927b0906322f12c8ed6de2da204d17fde8fb1f4"
+  integrity sha512-sLehZREpIAr1TDnefmZBSrIC0NsyebdQ8I1NJS+OTp/Rkpw1HOWuCzbYosbttlkMewinKgAYFcjE2B3EnS7hIA==
   dependencies:
     graphql-type-json "0.3.2"
     object-path "^0.11.4"


### PR DESCRIPTION
Relations that are defined on the base type composer are not copied to child type composers when adding the relation before adding the discriminators. The other way around it works correctly as `addRelation` check for children and adds the relation there.

The other important thing here is that the relations need to be copied before copying the fields. This is because copying the relations uses `addRelations` on the child which itself adds or changes the type of the field named the same as the relation.

In the following example we change the type to be non nullable. Would the fields be copied first we would copy the non-nullable field, and then add the relation which changes the type back to nullable.

```js
TechDebtDTC.addRelation("report", {
  resolver: () => ReportTC.getResolver("findById"),
  prepareArgs: {
    _ids: (source) => source.report,
  },
  projection: { report: true },
});

// We know it always exists so ensure it is non nullable
TechDebtDTC.extendField("report", { type: ReportTC.getTypeNonNull() });

TechDebtDTC.discriminator(...);
```

