### PR TITLE
fix: connection never returns undefined

### DIFF
--- a/src/resolvers/connection.ts
+++ b/src/resolvers/connection.ts
@@ -21,7 +21,7 @@ export function connection<TSource = any, TContext = any, TDoc extends Document 
   model: Model<TDoc>,
   tc: ObjectTypeComposer<TDoc, TContext>,
   opts?: ConnectionResolverOpts<TContext>
-): Resolver<TSource, TContext, ConnectionTArgs, TDoc> | undefined {
+): Resolver<TSource, TContext, ConnectionTArgs, TDoc> {
   const uniqueIndexes = extendByReversedIndexes(getUniqueIndexes(model), {
     reversedFirst: true,
   });


### PR DESCRIPTION
Fixes the typings of the `connection` resolver, which will never return `undefined` anyway. This was interfering with other type definitions. `mongooseResolvers.connection()` was returning `any` because in `GenerateResolverType`, the return type of `connection` didn't extend. `(...args: any) => Resolver<any, any, infer TArgs, any>` (because of `connection`'s extra `| undefined`). Simply removing that `| undefined` gets all of those types working again.