### PR TITLE
Improve typedefs for connection resolver factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,8 @@ UserTC.mongooseResolvers.findMany(opts);
 
 ```ts
 type ConnectionResolverOpts<TContext = any> = {
-  sort: ConnectionSortMapOpts;
+  /** See below **/
+  sort?: ConnectionSortMapOpts;
   name?: string;
   defaultLimit?: number | undefined;
   edgeTypeName?: string;
@@ -387,6 +388,15 @@ type ConnectionResolverOpts<TContext = any> = {
   findManyOpts?: FindManyResolverOpts;
 }
 ```
+
+The `countOpts` and `findManyOpts` props would be used to customize the internally created `findMany` and `count` resolver factories used by the connection resolver.
+If not provided the default configuration for each of the resolver factories is assumed.
+
+The `sort` prop is optional. When provided it is used to customize the sorting behaviour of the connection. When not provided, the sorting configuration is derived from the existing indexes on the model.
+
+Please refer to the documentation of the [graphql-compose-connection](https://github.com/graphql-compose/graphql-compose-connection) plugin for more details on the sorting customization parameter.
+
+
 
 ### `count(opts?: CountResolverOpts)`
 

--- a/src/resolvers/connection.ts
+++ b/src/resolvers/connection.ts
@@ -2,6 +2,7 @@ import type { Document, Model } from 'mongoose';
 import {
   prepareConnectionResolver,
   ConnectionResolverOpts as _ConnectionResolverOpts,
+  ConnectionSortMapOpts as _ConnectionSortMapOpts,
   ConnectionTArgs,
 } from 'graphql-compose-connection';
 import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
@@ -9,12 +10,22 @@ import { CountResolverOpts, count } from './count';
 import { FindManyResolverOpts, findMany } from './findMany';
 import { getUniqueIndexes, extendByReversedIndexes, IndexT } from '../utils/getIndexesFromModel';
 
+/**
+ * Allows customization of the generated `connection` resolver.
+ * 
+ * It is based on the `ConnectionResolverOpts` from: https://github.com/graphql-compose/graphql-compose-connection
+ * With the following changes:
+ * - `sort` prop is optional - when not provided derived from existing model indexes
+ * - `findManyResolver` prop is removed - use the optional `findManyOpts` to customize the internally created `findMany` resolver
+ * - `countResolver` prop is removed - use the optional `countOpts` to customize the internally created `count` resolver
+ */
 export type ConnectionResolverOpts<TContext = any> = Omit<
   _ConnectionResolverOpts<TContext>,
-  'countResolver' | 'findManyResolver'
+  'countResolver' | 'findManyResolver' | 'sort'
 > & {
   countOpts?: CountResolverOpts;
   findManyOpts?: FindManyResolverOpts;
+  sort?: _ConnectionSortMapOpts;
 };
 
 export function connection<TSource = any, TContext = any, TDoc extends Document = any>(

--- a/src/resolvers/connection.ts
+++ b/src/resolvers/connection.ts
@@ -12,7 +12,7 @@ import { getUniqueIndexes, extendByReversedIndexes, IndexT } from '../utils/getI
 
 /**
  * Allows customization of the generated `connection` resolver.
- * 
+ *
  * It is based on the `ConnectionResolverOpts` from: https://github.com/graphql-compose/graphql-compose-connection
  * With the following changes:
  * - `sort` prop is optional - when not provided derived from existing model indexes


### PR DESCRIPTION
This aims to improve docs + typedefs.
Mainly ensure "sort" is optional (since can be auto generated from unique indexes) and improve unit tests for connection resolver which did not reflect new behavior of customizing `findMany` and `count` resolvers.

This PR tries to resolve #337 