### PR TITLE
[WIP] - Feature: Discriminator Support on composeMongoose

### DIFF
--- a/src/discriminators/prepareBaseResolvers.ts
+++ b/src/discriminators/prepareBaseResolvers.ts
@@ -76,7 +76,7 @@ export function prepareBaseResolvers(baseTC: DiscriminatorTypeComposer<any, any>
           });
           break;
 
-        case 'connection':
+        case 'connection': {
           const edgesTC = resolver
             .getOTC()
             .getFieldOTC('edges')
@@ -91,6 +91,7 @@ export function prepareBaseResolvers(baseTC: DiscriminatorTypeComposer<any, any>
 
           resolver.getOTC().setField('edges', edgesTC.NonNull.List.NonNull);
           break;
+        }
 
         default:
       }

--- a/src/enhancedDiscriminators/__mocks__/characterDiscrimModels.ts
+++ b/src/enhancedDiscriminators/__mocks__/characterDiscrimModels.ts
@@ -1,0 +1,97 @@
+import type { Model } from 'mongoose';
+import { mongoose, Schema, Types } from '../../__mocks__/mongooseCommon';
+
+export const PersonSchema = new Schema({
+  dob: Number,
+  primaryFunction: [String],
+  starShips: [String],
+  totalCredits: Number,
+});
+
+export const DroidSchema = new Schema({
+  makeDate: Date,
+  modelNumber: Number,
+  primaryFunction: [String],
+});
+
+const MovieSchema = new Schema({
+  _id: String,
+
+  characters: {
+    type: [String], // redundant but i need it.
+    description: 'A character in the Movie, Person or Droid.',
+  },
+
+  director: {
+    type: String, // id of director
+    description: 'Directed the movie.',
+  },
+
+  imdbRatings: String,
+  releaseDate: String,
+});
+
+export const MovieModel = mongoose.model('Movie', MovieSchema);
+
+const enumCharacterType = {
+  PERSON: 'Person',
+  DROID: 'Droid',
+};
+
+export const CharacterObject = {
+  _id: {
+    type: String,
+    default: (): any => new Types.ObjectId(),
+  },
+  name: String,
+
+  type: {
+    type: String,
+    require: true,
+    enum: Object.keys(enumCharacterType),
+  },
+  kind: {
+    type: String,
+    require: true,
+    enum: Object.keys(enumCharacterType),
+  },
+
+  friends: [String], // another Character
+  appearsIn: [String], // movie
+};
+
+export function getCharacterModels(
+  DKey?: string,
+  name: string = 'Character'
+): { CharacterModel: Model<any>; PersonModel: Model<any>; DroidModel: Model<any> } {
+  const CharacterSchema = DKey
+    ? new Schema(CharacterObject, { discriminatorKey: DKey })
+    : new Schema(CharacterObject);
+
+  const CharacterModel: Model<any> = mongoose.model(name, CharacterSchema);
+
+  const PersonModel: Model<any> = CharacterModel.discriminator(
+    name + enumCharacterType.PERSON,
+    PersonSchema
+  );
+
+  const DroidModel: Model<any> = CharacterModel.discriminator(
+    name + enumCharacterType.DROID,
+    DroidSchema
+  );
+
+  return { CharacterModel, PersonModel, DroidModel };
+}
+
+export function getCharacterModelClone(): { NoDKeyCharacterModel: Model<any> } {
+  const ACharacterSchema = new Schema({ ...CharacterObject });
+  const NoDKeyCharacterModel = mongoose.model('NoDKeyCharacter', ACharacterSchema);
+
+  /*
+    const APersonModel = ACharacterModel.discriminator('A' + enumCharacterType.PERSON, PersonSchema.clone());
+
+    const ADroidModel = ACharacterModel.discriminator('A' + enumCharacterType.DROID, DroidSchema.clone());
+  */
+
+  return { NoDKeyCharacterModel }; // APersonModel, ADroidModel };
+}

--- a/src/enhancedDiscriminators/__tests__/eDiscriminatorTypeComposer-test.ts
+++ b/src/enhancedDiscriminators/__tests__/eDiscriminatorTypeComposer-test.ts
@@ -6,7 +6,7 @@ import {
   GenerateResolverType,
 } from '../../composeMongoose';
 import { EDiscriminatorTypeComposer } from '../eDiscriminatorTypeComposer';
-import { Document, Model, Schema } from 'mongoose';
+import mongoose, { Document, Model, Schema } from 'mongoose';
 
 const defaultDKey = 'type';
 const { CharacterModel } = getCharacterModels(defaultDKey);
@@ -80,15 +80,13 @@ describe('EDiscriminatorTypeComposer', () => {
 
   describe('createFromModel errors', () => {
     it('should throw an error if it is called with no discriminators present', () => {
+      const fakeModel = mongoose.model(
+        'fakeModelEDiscrim',
+        new Schema({ test: String, thingy: Boolean })
+      );
+
       const errorCall = () =>
-        EDiscriminatorTypeComposer.createFromModel(
-          {
-            schema: new Schema({ test: String, thingy: Boolean }),
-          },
-          'noDiscrimType',
-          schemaComposer,
-          {}
-        );
+        EDiscriminatorTypeComposer.createFromModel(fakeModel, 'noDiscrimType', schemaComposer, {});
 
       expect(errorCall).toThrowError('Discriminators should be present to use this function');
     });

--- a/src/enhancedDiscriminators/__tests__/eDiscriminatorTypeComposer-test.ts
+++ b/src/enhancedDiscriminators/__tests__/eDiscriminatorTypeComposer-test.ts
@@ -122,6 +122,20 @@ describe('EDiscriminatorTypeComposer', () => {
     });
   });
 
+  describe('Get Discriminator TCs', () => {
+    it('returns discrimTCs with mongooseResolvers present', () => {
+      Object.values(baseDTC.getDiscriminatorTCs()).forEach((discimTC) => {
+        expect(discimTC).toHaveProperty('mongooseResolvers');
+      });
+    });
+    it('returns empty object with mongooseResolvers missing', () => {
+      (baseDTC.discrimTCs[Object.keys(baseDTC.discrimTCs)[0]] as any).mongooseResolvers = undefined;
+      Object.values(baseDTC.getDiscriminatorTCs()).forEach((discimTC) => {
+        expect(discimTC).toHaveProperty('mongooseResolvers');
+      });
+    });
+  });
+
   describe('Overridden eDTC Class Methods', () => {
     describe('Set Field', () => {
       it('updates field on all child TCs', () => {

--- a/src/enhancedDiscriminators/__tests__/eDiscriminatorTypeComposer-test.ts
+++ b/src/enhancedDiscriminators/__tests__/eDiscriminatorTypeComposer-test.ts
@@ -1,0 +1,220 @@
+import { InterfaceTypeComposer, ObjectTypeComposer, schemaComposer } from 'graphql-compose';
+import { getCharacterModels } from '../__mocks__/characterDiscrimModels';
+import {
+  composeMongoose as composeMongooseRaw,
+  ComposeMongooseOpts,
+  GenerateResolverType,
+} from '../../composeMongoose';
+import { EDiscriminatorTypeComposer } from '../eDiscriminatorTypeComposer';
+import { Document, Model, Schema } from 'mongoose';
+
+const defaultDKey = 'type';
+const { CharacterModel } = getCharacterModels(defaultDKey);
+
+const dComposeOpts: ComposeMongooseOpts = {
+  includeBaseDiscriminators: true,
+  schemaComposer: schemaComposer,
+};
+
+const composeMongoose = <TDoc extends Document, TContext = any>(
+  model: Model<TDoc>
+): EDiscriminatorTypeComposer<TDoc, TContext> & {
+  mongooseResolvers: GenerateResolverType<TDoc, TContext>;
+} => {
+  const generatedTC = composeMongooseRaw(model, dComposeOpts);
+
+  if (!(generatedTC instanceof EDiscriminatorTypeComposer)) {
+    throw new Error('Model should include discriminated schema for testing here');
+  }
+
+  return generatedTC;
+};
+
+let baseDTC: EDiscriminatorTypeComposer<any, any>;
+let DInterface: InterfaceTypeComposer<any, any>;
+let DInputObject: ObjectTypeComposer<any, any>;
+
+beforeEach(() => {
+  baseDTC = composeMongoose(CharacterModel);
+  DInterface = schemaComposer.getIFTC(baseDTC.getTypeName());
+  DInputObject = baseDTC.getDInputObject();
+});
+
+afterEach(() => {
+  baseDTC.schemaComposer.clear();
+});
+
+describe('EDiscriminatorTypeComposer', () => {
+  it('has an interface object DInterface as the type name', () => {
+    expect(baseDTC.getDInterface()).toEqual(schemaComposer.getAnyTC(baseDTC.getTypeName()));
+  });
+
+  it('throws an error when default (__t) discriminator key is set', () => {
+    baseDTC.schemaComposer.clear();
+    const { CharacterModel: noDKeyModel } = getCharacterModels(undefined, 'noDKeyCharacter');
+    const errorCall = () => composeMongoose(noDKeyModel);
+    expect(errorCall).toThrowError(
+      'A custom discriminator key must be set on the model options in mongoose for discriminator behaviour to function correctly'
+    );
+  });
+
+  it('should not be used on models without discriminators', () => {
+    const { DroidModel } = getCharacterModels(undefined, 'noDiscrim');
+    const noDiscrim = composeMongooseRaw(DroidModel, dComposeOpts);
+    expect(noDiscrim instanceof EDiscriminatorTypeComposer).toBeFalsy();
+  });
+
+  describe('Custom Getters', () => {
+    test('getting discriminator key', () => {
+      expect(baseDTC.getDKey()).toEqual(defaultDKey);
+    });
+
+    test('getting discriminator interface', () => {
+      expect(baseDTC.getDInterface()).toBe(DInterface);
+    });
+
+    test('getting discriminator input object TC', () => {
+      expect(baseDTC.getDInputObject()).toBe(DInputObject);
+    });
+  });
+
+  describe('createFromModel errors', () => {
+    it('should throw an error if it is called with no discriminators present', () => {
+      const errorCall = () =>
+        EDiscriminatorTypeComposer.createFromModel(
+          {
+            schema: new Schema({ test: String, thingy: Boolean }),
+          },
+          'noDiscrimType',
+          schemaComposer,
+          {}
+        );
+
+      expect(errorCall).toThrowError('Discriminators should be present to use this function');
+    });
+
+    it('should throw an error if the schema composer is not valid', () => {
+      const { CharacterModel: errorTestModel } = getCharacterModels('type', 'scErrorModel');
+
+      const errorCall = () =>
+        EDiscriminatorTypeComposer.createFromModel(errorTestModel, 'noSCType', {} as any, {});
+      expect(errorCall).toThrowError(
+        'DiscriminatorTC.createFromModel() should receive SchemaComposer in second argument'
+      );
+    });
+  });
+
+  describe('DInterface', () => {
+    it('shares field names with base model used to compose it', () => {
+      expect(DInterface.getFieldNames()).toEqual(
+        expect.arrayContaining(
+          Object.keys(CharacterModel.schema.paths).filter((x) => !x.startsWith('__'))
+        )
+      );
+    });
+
+    it('should be an instance of InterfaceTypeComposer', () => {
+      expect(DInterface instanceof InterfaceTypeComposer).toBeTruthy();
+    });
+
+    it('should have the input TC from DInputObject as input TC', () => {
+      expect(DInterface.getInputTypeComposer()).toEqual(
+        baseDTC.getDInputObject().getInputTypeComposer()
+      );
+    });
+  });
+
+  describe('Overridden eDTC Class Methods', () => {
+    describe('Set Field', () => {
+      it('updates field on all child TCs', () => {
+        baseDTC.setField('newField', 'String');
+        expect(baseDTC.hasField('newField')).toBeTruthy();
+        expect(DInterface.hasField('newField')).toBeTruthy();
+        expect(DInputObject.hasField('newField')).toBeTruthy();
+        Object.values(baseDTC.discrimTCs).forEach((dTC) => {
+          expect(dTC.hasField('newField')).toBeTruthy();
+        });
+      });
+
+      it('updates input TC when field is added', () => {
+        baseDTC.setField('inputField', 'String');
+        expect(schemaComposer.getIFTC(baseDTC.getTypeName()).getInputTypeComposer()).toEqual(
+          DInputObject.getInputTypeComposer()
+        );
+      });
+    });
+
+    describe('Set Extensions', () => {
+      it('updates field on all child TCs', () => {
+        baseDTC.setExtensions({ newField: 'testExtension' });
+        expect(baseDTC.hasExtension('newField')).toBeTruthy();
+        expect(DInterface.hasExtension('newField')).toBeTruthy();
+        expect(DInputObject.hasExtension('newField')).toBeTruthy();
+        Object.values(baseDTC.discrimTCs).forEach((dTC) => {
+          expect(dTC.hasExtension('newField')).toBeTruthy();
+        });
+      });
+    });
+
+    describe('Remove Field', () => {
+      it('deletes field on all child TCs', () => {
+        baseDTC.addFields({ toDelete: 'String' });
+        // check field added
+        expect(baseDTC.hasField('toDelete')).toBeTruthy();
+        expect(DInterface.hasField('toDelete')).toBeTruthy();
+        expect(DInputObject.hasField('toDelete')).toBeTruthy();
+        Object.values(baseDTC.discrimTCs).forEach((dTC) => {
+          expect(dTC.hasField('toDelete')).toBeTruthy();
+        });
+
+        baseDTC.removeField('toDelete');
+        expect(baseDTC.hasField('toDelete')).toBeFalsy();
+        expect(DInterface.hasField('toDelete')).toBeFalsy();
+        expect(DInputObject.hasField('toDelete')).toBeFalsy();
+        Object.values(baseDTC.discrimTCs).forEach((dTC) => {
+          expect(dTC.hasField('toDelete')).toBeFalsy();
+        });
+      });
+    });
+
+    describe('Remove Other Fields', () => {
+      it('removes all other fields from base TC from all child TCs', () => {
+        baseDTC.addFields({ toKeep: 'String' });
+
+        const otherFields = baseDTC
+          .getDInterface()
+          .getFieldNames()
+          .filter((field) => field !== 'toKeep');
+        baseDTC.removeOtherFields('toKeep');
+
+        console.log(otherFields);
+
+        otherFields.forEach((removedField) => {
+          expect(baseDTC.hasField(removedField)).toBeFalsy();
+          expect(DInterface.hasField(removedField)).toBeFalsy();
+          expect(DInputObject.hasField(removedField)).toBeFalsy();
+          Object.values(baseDTC.discrimTCs).forEach((dTC) => {
+            expect(dTC.hasField(removedField)).toBeFalsy();
+          });
+        });
+      });
+    });
+
+    describe('Reorder Fields', () => {
+      it('reorders fields on all child TCs', () => {
+        const fieldOrder = ['_id', 'appearsIn', 'friends', 'kind', 'type'];
+        const fieldOrderString = fieldOrder.join('');
+        console.log(fieldOrderString);
+
+        baseDTC.reorderFields(fieldOrder);
+
+        expect(baseDTC.getFieldNames().join('').startsWith(fieldOrderString)).toBeTruthy();
+        expect(DInterface.getFieldNames().join('').startsWith(fieldOrderString)).toBeTruthy();
+        expect(DInputObject.getFieldNames().join('').startsWith(fieldOrderString)).toBeTruthy();
+        Object.values(baseDTC.discrimTCs).forEach((dTC) => {
+          expect(dTC.getFieldNames().join('').startsWith(fieldOrderString)).toBeTruthy();
+        });
+      });
+    });
+  });
+});

--- a/src/enhancedDiscriminators/eDiscriminatorTypeComposer.ts
+++ b/src/enhancedDiscriminators/eDiscriminatorTypeComposer.ts
@@ -1,0 +1,266 @@
+import { GraphQLObjectType } from 'graphql';
+import {
+  EnumTypeComposer,
+  Extensions,
+  InterfaceTypeComposer,
+  ObjectTypeComposer,
+  ObjectTypeComposerFieldConfigDefinition,
+  SchemaComposer,
+} from 'graphql-compose';
+import mongoose, { Document, Model } from 'mongoose';
+import { convertModelToGraphQL, MongoosePseudoModelT } from '../fieldsConverter';
+import { composeMongoose, ComposeMongooseOpts } from '../composeMongoose';
+
+export function convertModelToGraphQLWithDiscriminators<TDoc extends Document, TContext>(
+  model: Model<TDoc> | MongoosePseudoModelT,
+  typeName: string,
+  schemaComposer: SchemaComposer<TContext>,
+  opts: ComposeMongooseOpts<any> = {}
+): ObjectTypeComposer<TDoc, TContext> {
+  const sc = schemaComposer;
+
+  // workaround to avoid recursive loop on convertModel and support nested discrim fields, will be set true in nested fields
+  // if includeNestedDiscriminators is true to indicate that convertModel should invoke this method
+  opts.includeBaseDiscriminators = false;
+
+  if (!model.schema.discriminators) {
+    return convertModelToGraphQL(model, typeName, sc, opts);
+  } else {
+    return EDiscriminatorTypeComposer.createFromModel(model, typeName, sc, opts);
+  }
+}
+
+export interface ComposeMongooseDiscriminatorsOpts<TContext> extends ComposeMongooseOpts<TContext> {
+  reorderFields?: boolean | string[]; // true order: _id, DKey, DInterfaceFields, DiscriminatorFields
+}
+
+export class EDiscriminatorTypeComposer<TSource, TContext> extends ObjectTypeComposer<
+  TSource,
+  TContext
+> {
+  discriminatorKey: string = '';
+  discrimTCs: { [key: string]: ObjectTypeComposer<any, TContext> } = {};
+  DInputObject: ObjectTypeComposer<TSource, TContext>;
+  DInterface: InterfaceTypeComposer<TSource, TContext>;
+  opts: ComposeMongooseDiscriminatorsOpts<TContext> = {};
+  DKeyETC?: EnumTypeComposer<TContext>;
+
+  constructor(gqType: GraphQLObjectType, schemaComposer: SchemaComposer<TContext>) {
+    super(gqType, schemaComposer);
+    this.DInterface = schemaComposer.getOrCreateIFTC(`${gqType.name}Interface`);
+    this.DInputObject = schemaComposer.getOrCreateOTC(`${gqType.name}Input`);
+    return this;
+  }
+
+  static createFromModel<TSrc = any, TCtx = any>(
+    model: Model<any> | MongoosePseudoModelT,
+    typeName: string,
+    schemaComposer: SchemaComposer<TCtx>,
+    opts: ComposeMongooseDiscriminatorsOpts<any>
+  ): EDiscriminatorTypeComposer<TSrc, TCtx> {
+    if (!model.schema.discriminators) {
+      throw Error('Discriminators should be present to use this function');
+    }
+
+    if (!(schemaComposer instanceof SchemaComposer)) {
+      throw Error(
+        'DiscriminatorTC.createFromModel() should receive SchemaComposer in second argument'
+      );
+    }
+
+    opts = {
+      reorderFields: true,
+      schemaComposer,
+      ...opts,
+    };
+
+    const baseTC = convertModelToGraphQL(model, typeName, schemaComposer, opts);
+    const baseDTC = new EDiscriminatorTypeComposer(baseTC.getType(), schemaComposer);
+
+    // copy data from baseTC to baseDTC
+    baseTC.clone(baseDTC as ObjectTypeComposer<any, any>);
+
+    baseDTC.opts = { ...opts };
+    baseDTC.discriminatorKey = (model as any).schema.options.discriminatorKey;
+    if (baseDTC.discriminatorKey === '__t') {
+      throw Error(
+        'A custom discriminator key must be set on the model options in mongoose for discriminator behaviour to function correctly'
+      );
+    }
+    baseDTC.DInterface = baseDTC._buildDiscriminatedInterface(model, baseTC);
+    baseDTC.DInterface.setInputTypeComposer(baseDTC.DInputObject.getInputTypeComposer());
+    baseDTC.setInputTypeComposer(baseDTC.DInputObject.getInputTypeComposer());
+
+    baseDTC.setInterfaces([baseDTC.DInterface]);
+    baseDTC._gqcInputTypeComposer = baseDTC.DInputObject._gqcInputTypeComposer;
+    baseDTC.DInterface._gqcInputTypeComposer = baseDTC.DInputObject._gqcInputTypeComposer;
+
+    // discriminators an object containing all discriminators with key being DNames
+    // import { EDiscriminatorTypeComposer } from './enhancedDiscriminators/index';baseDTC.DKeyETC = createAndSetDKeyETC(baseDTC, discriminators);
+
+    // reorderFields(baseDTC, baseDTC.opts.reorderFields, baseDTC.discriminatorKey);
+    baseDTC.schemaComposer.addSchemaMustHaveType(baseDTC as any);
+
+    // prepare Base Resolvers
+    // prepareBaseResolvers(baseDTC);
+
+    return baseDTC as any;
+  }
+
+  _buildDiscriminatedInterface(
+    model: Model<any> | MongoosePseudoModelT,
+    baseTC: ObjectTypeComposer<any, TContext>
+  ): InterfaceTypeComposer<TSource, TContext> {
+    const interfaceTC = this.DInterface;
+    interfaceTC.removeOtherFields('');
+    interfaceTC.setFields(baseTC.getFields());
+    this.DInputObject.setFields(baseTC.getFields());
+
+    Object.keys((model as any).schema.discriminators).forEach((key) => {
+      const discrimType = (model as any).schema.discriminators[key];
+
+      // ensure valid type for calling convert
+      const discrimModel =
+        discrimType instanceof mongoose.Schema ? { schema: discrimType } : discrimType;
+
+      const discrimTC = composeMongoose(discrimModel, {
+        ...this.opts,
+        name: this.getTypeName() + key,
+      });
+
+      // base OTC used for input schema must hold all child TC fields in the most loose way (so all types are accepted)
+      // more detailed type checks are done on input object by mongoose itself
+      // TODO - Review when Input Unions/similar are accepted into the graphQL spec and supported by graphql-js
+      // SEE - https://github.com/graphql/graphql-spec/blob/main/rfcs/InputUnion.md
+      const discrimFields = discrimTC.getFields();
+      Object.keys(discrimFields).forEach((fieldName) => {
+        const field = discrimFields[fieldName];
+
+        // if another discrimTC has already defined the field (not from original TC)
+        if (this.DInputObject.hasField(fieldName) && !baseTC.hasField(fieldName)) {
+          this.DInputObject.setField(fieldName, `JSON`);
+        } else {
+          (this.DInputObject as ObjectTypeComposer<any, any>).setField(fieldName, field);
+        }
+      });
+      this.DInputObject.makeFieldNullable(
+        discrimTC.getFieldNames().filter((field) => !baseTC.hasField(field))
+      );
+      // there may be issues for discriminated types with overlapping fields, the last validation req will overwrite prior one
+      // mitigation attempted by setting type to any on filed which appears in multiple implementations
+      discrimTC.makeFieldNonNull('_id');
+
+      // also set fields on master TC so it will have all possibilities for input workaround
+
+      const discrimVal = discrimType.discriminatorMapping.value;
+      interfaceTC.addTypeResolver(
+        discrimTC,
+        (obj: any) => obj[this.discriminatorKey] === discrimVal
+      );
+
+      // add TC to discrimTCs
+      this.discrimTCs[discrimTC.getTypeName()] = discrimTC;
+    });
+
+    return interfaceTC;
+  }
+
+  getDKey(): string {
+    return this.discriminatorKey;
+  }
+
+  // getDKeyETC(): EnumTypeComposer<TContext> {
+  //   return this.DKeyETC as any;
+  // }
+
+  getDInterface(): InterfaceTypeComposer<TSource, TContext> {
+    return this.DInterface as any;
+  }
+
+  getDInputObject(): ObjectTypeComposer<TSource, TContext> {
+    return this.DInputObject as any;
+  }
+
+  // OVERRIDES
+  getTypeName(): string {
+    return this.DInterface.getTypeName();
+  }
+
+  setField(
+    fieldName: string,
+    fieldConfig: ObjectTypeComposerFieldConfigDefinition<any, any>
+  ): this {
+    super.setField(fieldName, fieldConfig);
+    this.getDInputObject().setField(fieldName, fieldConfig);
+    this.getDInterface().setField(fieldName, fieldConfig);
+
+    for (const discrimTC in this.discrimTCs) {
+      this.discrimTCs[discrimTC].setField(fieldName, fieldConfig);
+    }
+
+    return this;
+  }
+
+  setExtensions(extensions: Extensions): this {
+    super.setExtensions(extensions);
+    this.getDInputObject().setExtensions(extensions);
+    this.getDInterface().setExtensions(extensions);
+
+    for (const discrimTC in this.discrimTCs) {
+      this.discrimTCs[discrimTC].setExtensions(extensions);
+    }
+
+    return this;
+  }
+
+  setDescription(description: string): this {
+    super.setDescription(description);
+    this.getDInputObject().setDescription(description);
+    this.getDInterface().setDescription(description);
+
+    return this;
+  }
+
+  removeField(fieldNameOrArray: string | Array<string>): this {
+    super.removeField(fieldNameOrArray);
+    this.getDInputObject().removeField(fieldNameOrArray);
+    this.getDInterface().removeField(fieldNameOrArray);
+
+    for (const discrimTC in this.discrimTCs) {
+      this.discrimTCs[discrimTC].removeField(fieldNameOrArray);
+    }
+
+    return this;
+  }
+
+  removeOtherFields(fieldNameOrArray: string | Array<string>): this {
+    // get field names to delete from child TCs, so their unique fields are preserved
+    const keepFieldNames =
+      fieldNameOrArray instanceof Array ? fieldNameOrArray : [fieldNameOrArray];
+    const fieldNamesToDelete = this.DInterface.getFieldNames().filter(
+      (field) => !keepFieldNames.includes(field)
+    );
+
+    super.removeField(fieldNamesToDelete);
+    this.getDInputObject().removeField(fieldNamesToDelete);
+    this.getDInterface().removeOtherFields(fieldNameOrArray);
+
+    for (const discrimTC in this.discrimTCs) {
+      this.discrimTCs[discrimTC].removeField(fieldNamesToDelete);
+    }
+
+    return this;
+  }
+
+  reorderFields(names: string[]): this {
+    super.reorderFields(names);
+    this.getDInterface().reorderFields(names);
+    this.getDInputObject().reorderFields(names);
+
+    for (const discrimTC in this.discrimTCs) {
+      this.discrimTCs[discrimTC].reorderFields(names);
+    }
+
+    return this;
+  }
+}

--- a/src/enhancedDiscriminators/eDiscriminatorTypeComposer.ts
+++ b/src/enhancedDiscriminators/eDiscriminatorTypeComposer.ts
@@ -218,7 +218,7 @@ export class EDiscriminatorTypeComposer<TSource, TContext> extends ObjectTypeCom
       mongooseResolvers: GenerateResolverType<any, TContext>;
     };
   } {
-    // check if mongooseResolvers are present
+    // check if mongooseResolvers are present (assume on one = on all)
     if ((this.discrimTCs[Object.keys(this.discrimTCs)[0]] as any).mongooseResolvers) {
       return this.discrimTCs as any;
     } else {

--- a/src/enhancedDiscriminators/eDiscriminatorTypeComposer.ts
+++ b/src/enhancedDiscriminators/eDiscriminatorTypeComposer.ts
@@ -10,7 +10,7 @@ import {
 } from 'graphql-compose';
 import mongoose, { Document, Model } from 'mongoose';
 import { convertModelToGraphQL, MongoosePseudoModelT } from '../fieldsConverter';
-import { composeMongoose, ComposeMongooseOpts } from '../composeMongoose';
+import { composeMongoose, ComposeMongooseOpts, GenerateResolverType } from '../composeMongoose';
 
 export function convertModelToGraphQLWithDiscriminators<TDoc extends Document, TContext>(
   model: Model<TDoc> | MongoosePseudoModelT,
@@ -40,7 +40,12 @@ export class EDiscriminatorTypeComposer<TSource, TContext> extends ObjectTypeCom
   TContext
 > {
   discriminatorKey: string = '';
-  discrimTCs: { [key: string]: ObjectTypeComposer<any, TContext> } = {};
+  discrimTCs: {
+    [key: string]: ObjectTypeComposer<any, TContext> & {
+      mongooseResolvers: GenerateResolverType<any, TContext>;
+    };
+  } = {};
+
   BaseTC: ObjectTypeComposer<TSource, TContext>;
   DInputObject: ObjectTypeComposer<TSource, TContext>;
   DInterface: InterfaceTypeComposer<TSource, TContext>;

--- a/src/enhancedDiscriminators/index.ts
+++ b/src/enhancedDiscriminators/index.ts
@@ -1,0 +1,4 @@
+export {
+  EDiscriminatorTypeComposer,
+  convertModelToGraphQLWithDiscriminators,
+} from './eDiscriminatorTypeComposer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ export * from './composeWithMongooseDiscriminators';
 export * from './fieldsConverter';
 export * from './resolvers';
 export * from './errors';
+export * from './enhancedDiscriminators';
 export { GraphQLMongoID, GraphQLBSONDecimal };

--- a/src/resolvers/connection.ts
+++ b/src/resolvers/connection.ts
@@ -4,7 +4,7 @@ import {
   ConnectionResolverOpts as _ConnectionResolverOpts,
   ConnectionTArgs,
 } from 'graphql-compose-connection';
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import { CountResolverOpts, count } from './count';
 import { FindManyResolverOpts, findMany } from './findMany';
 import { getUniqueIndexes, extendByReversedIndexes, IndexT } from '../utils/getIndexesFromModel';

--- a/src/resolvers/count.ts
+++ b/src/resolvers/count.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   filterHelper,
@@ -29,7 +29,7 @@ export function count<TSource = any, TContext = any, TDoc extends Document = any
     throw new Error('First arg for Resolver count() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error('Second arg for Resolver count() should be instance of ObjectTypeComposer.');
   }
 

--- a/src/resolvers/createMany.ts
+++ b/src/resolvers/createMany.ts
@@ -29,7 +29,7 @@ export function createMany<TSource = any, TContext = any, TDoc extends Document 
     throw new Error('First arg for Resolver createMany() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver createMany() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/createOne.ts
+++ b/src/resolvers/createOne.ts
@@ -30,7 +30,7 @@ export function createOne<TSource = any, TContext = any, TDoc extends Document =
     throw new Error('First arg for Resolver createOne() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver createOne() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/createOne.ts
+++ b/src/resolvers/createOne.ts
@@ -52,7 +52,7 @@ export function createOne<TSource = any, TContext = any, TDoc extends Document =
     t.setFields({
       ...payloadRecordId(tc, opts?.recordId),
       record: {
-        type: tc,
+        type: tc.getTypeName(),
         description: 'Created document',
       },
     });

--- a/src/resolvers/dataLoader.ts
+++ b/src/resolvers/dataLoader.ts
@@ -1,5 +1,4 @@
-import { toInputType } from 'graphql-compose';
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer, toInputType } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   projectionHelper,
@@ -40,7 +39,7 @@ export function dataLoader<TSource = any, TContext = any, TDoc extends Document 
     throw new Error('First arg for Resolver dataLoader() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver dataLoader() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/dataLoader.ts
+++ b/src/resolvers/dataLoader.ts
@@ -49,7 +49,7 @@ export function dataLoader<TSource = any, TContext = any, TDoc extends Document 
   const aliasesReverse = prepareAliasesReverse(model.schema);
 
   return tc.schemaComposer.createResolver<TSource, TArgs>({
-    type: tc,
+    type: tc.getTypeName(),
     name: 'dataLoader',
     kind: 'query',
     args: {

--- a/src/resolvers/dataLoaderMany.ts
+++ b/src/resolvers/dataLoaderMany.ts
@@ -1,5 +1,4 @@
-import { toInputType } from 'graphql-compose';
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer, toInputType } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   projectionHelper,
@@ -42,7 +41,7 @@ export function dataLoaderMany<TSource = any, TContext = any, TDoc extends Docum
     );
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver dataLoaderMany() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/dataLoaderMany.ts
+++ b/src/resolvers/dataLoaderMany.ts
@@ -51,7 +51,7 @@ export function dataLoaderMany<TSource = any, TContext = any, TDoc extends Docum
   const aliasesReverse = prepareAliasesReverse(model.schema);
 
   return tc.schemaComposer.createResolver<TSource, TArgs>({
-    type: tc.List.NonNull,
+    type: tc.schemaComposer.getAnyTC(tc.getTypeName()).List.NonNull,
     name: 'dataLoaderMany',
     kind: 'query',
     args: {

--- a/src/resolvers/findById.ts
+++ b/src/resolvers/findById.ts
@@ -1,5 +1,4 @@
-import { toInputType } from 'graphql-compose';
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer, toInputType } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   projectionHelper,
@@ -9,6 +8,7 @@ import {
 } from './helpers';
 import type { ExtendedResolveParams } from './index';
 import { beforeQueryHelper, beforeQueryHelperLean } from './helpers/beforeQueryHelper';
+// import { EDiscriminatorTypeComposer } from '../enhancedDiscriminators';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FindByIdResolverOpts {
@@ -39,15 +39,17 @@ export function findById<TSource = any, TContext = any, TDoc extends Document = 
     throw new Error('First arg for Resolver findById() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error('Second arg for Resolver findById() should be instance of ObjectTypeComposer.');
   }
 
   const aliases = prepareNestedAliases(model.schema);
   const aliasesReverse = prepareAliasesReverse(model.schema);
 
+  // const typeTC = tc instanceof EDiscriminatorTypeComposer ? tc.getDInterface() : tc;
+
   return tc.schemaComposer.createResolver<TSource, TArgs>({
-    type: tc,
+    type: tc.getTypeName(),
     name: 'findById',
     kind: 'query',
     args: {

--- a/src/resolvers/findByIds.ts
+++ b/src/resolvers/findByIds.ts
@@ -57,7 +57,7 @@ export function findByIds<TSource = any, TContext = any, TDoc extends Document =
   const aliasesReverse = prepareAliasesReverse(model.schema);
 
   return tc.schemaComposer.createResolver<TSource, TArgs>({
-    type: tc.NonNull.List.NonNull,
+    type: tc.schemaComposer.getAnyTC(tc.getTypeName()).NonNull.List.NonNull,
     name: 'findByIds',
     kind: 'query',
     args: {

--- a/src/resolvers/findByIds.ts
+++ b/src/resolvers/findByIds.ts
@@ -1,5 +1,4 @@
-import { toInputType } from 'graphql-compose';
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer, toInputType } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   limitHelper,
@@ -48,7 +47,7 @@ export function findByIds<TSource = any, TContext = any, TDoc extends Document =
     throw new Error('First arg for Resolver findByIds() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver findByIds() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/findMany.ts
+++ b/src/resolvers/findMany.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   limitHelper,
@@ -58,7 +58,7 @@ export function findMany<TSource = any, TContext = any, TDoc extends Document = 
     throw new Error('First arg for Resolver findMany() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error('Second arg for Resolver findMany() should be instance of ObjectTypeComposer.');
   }
 
@@ -66,7 +66,7 @@ export function findMany<TSource = any, TContext = any, TDoc extends Document = 
   const aliasesReverse = prepareAliasesReverse(model.schema);
 
   return tc.schemaComposer.createResolver<TSource, TArgs>({
-    type: tc.NonNull.List.NonNull,
+    type: tc.schemaComposer.getAnyTC(tc.getTypeName()).NonNull.List.NonNull,
     name: 'findMany',
     kind: 'query',
     args: {

--- a/src/resolvers/findOne.ts
+++ b/src/resolvers/findOne.ts
@@ -61,7 +61,7 @@ export function findOne<TSource = any, TContext = any, TDoc extends Document = a
   const aliasesReverse = prepareAliasesReverse(model.schema);
 
   return tc.schemaComposer.createResolver<TSource, TArgs>({
-    type: tc,
+    type: tc.getTypeName(),
     name: 'findOne',
     kind: 'query',
     args: {

--- a/src/resolvers/findOne.ts
+++ b/src/resolvers/findOne.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   skipHelper,
@@ -53,7 +53,7 @@ export function findOne<TSource = any, TContext = any, TDoc extends Document = a
     throw new Error('First arg for Resolver findOne() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error('Second arg for Resolver findOne() should be instance of ObjectTypeComposer.');
   }
 

--- a/src/resolvers/helpers/record.ts
+++ b/src/resolvers/helpers/record.ts
@@ -45,7 +45,7 @@ export function recordHelperArgs<TDoc extends Document = any>(
   tc: ObjectTypeComposer<TDoc, any>,
   opts?: RecordHelperArgsOpts
 ): ObjectTypeComposerArgumentConfigMapDefinition<{ record: any }> {
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error('First arg for recordHelperArgs() should be instance of ObjectTypeComposer.');
   }
 

--- a/src/resolvers/helpers/sort.ts
+++ b/src/resolvers/helpers/sort.ts
@@ -28,7 +28,7 @@ export function sortHelperArgs<TDoc extends Document = any>(
   model: Model<TDoc>,
   opts?: SortHelperArgsOpts
 ): ObjectTypeComposerArgumentConfigMapDefinition<{ sort: any }> {
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error('First arg for sortHelperArgs() should be instance of ObjectTypeComposer.');
   }
 

--- a/src/resolvers/pagination.ts
+++ b/src/resolvers/pagination.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   preparePaginationResolver,

--- a/src/resolvers/removeById.ts
+++ b/src/resolvers/removeById.ts
@@ -40,7 +40,7 @@ export function removeById<TSource = any, TContext = any, TDoc extends Document 
     t.setFields({
       ...payloadRecordId(tc, opts?.recordId),
       record: {
-        type: tc,
+        type: tc.getTypeName(),
         description: 'Removed document',
       },
     });

--- a/src/resolvers/removeById.ts
+++ b/src/resolvers/removeById.ts
@@ -1,5 +1,4 @@
-import { toInputType } from 'graphql-compose';
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer, toInputType } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import { findById } from './findById';
 import type { ExtendedResolveParams } from './index';
@@ -28,7 +27,7 @@ export function removeById<TSource = any, TContext = any, TDoc extends Document 
     throw new Error('First arg for Resolver removeById() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver removeById() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/removeMany.ts
+++ b/src/resolvers/removeMany.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   filterHelperArgs,
@@ -35,7 +35,7 @@ export function removeMany<TSource = any, TContext = any, TDoc extends Document 
     throw new Error('First arg for Resolver removeMany() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver removeMany() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/removeOne.ts
+++ b/src/resolvers/removeOne.ts
@@ -50,7 +50,7 @@ export function removeOne<TSource = any, TContext = any, TDoc extends Document =
     t.setFields({
       ...payloadRecordId(tc, opts?.recordId),
       record: {
-        type: tc,
+        type: tc.getTypeName(),
         description: 'Removed document',
       },
     });

--- a/src/resolvers/removeOne.ts
+++ b/src/resolvers/removeOne.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   filterHelperArgs,
@@ -37,7 +37,7 @@ export function removeOne<TSource = any, TContext = any, TDoc extends Document =
     throw new Error('First arg for Resolver removeOne() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver removeOne() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/updateById.ts
+++ b/src/resolvers/updateById.ts
@@ -1,5 +1,4 @@
-import { toInputType } from 'graphql-compose';
-import { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer, toInputType } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import { recordHelperArgs, RecordHelperArgsOpts } from './helpers/record';
 import { findById } from './findById';
@@ -33,7 +32,7 @@ export function updateById<TSource = any, TContext = any, TDoc extends Document 
     throw new Error('First arg for Resolver updateById() should be instance of Mongoose Model.');
   }
 
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver updateById() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/updateById.ts
+++ b/src/resolvers/updateById.ts
@@ -45,7 +45,7 @@ export function updateById<TSource = any, TContext = any, TDoc extends Document 
     t.setFields({
       ...payloadRecordId(tc, opts?.recordId),
       record: {
-        type: tc,
+        type: tc.getTypeName(),
         description: 'Updated document',
       },
     });

--- a/src/resolvers/updateMany.ts
+++ b/src/resolvers/updateMany.ts
@@ -1,4 +1,4 @@
-import type { Resolver, ObjectTypeComposer } from 'graphql-compose';
+import { Resolver, ObjectTypeComposer } from 'graphql-compose';
 import type { Model, Document } from 'mongoose';
 import {
   limitHelper,
@@ -51,7 +51,7 @@ export function updateMany<TSource = any, TContext = any, TDoc extends Document 
   if (!model || !model.modelName || !model.schema) {
     throw new Error('First arg for Resolver updateMany() should be instance of Mongoose Model.');
   }
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver updateMany() should be instance of ObjectTypeComposer.'
     );

--- a/src/resolvers/updateOne.ts
+++ b/src/resolvers/updateOne.ts
@@ -58,7 +58,7 @@ export function updateOne<TSource = any, TContext = any, TDoc extends Document =
     t.setFields({
       ...payloadRecordId(tc, opts?.recordId),
       record: {
-        type: tc,
+        type: tc.getTypeName(),
         description: 'Updated document',
       },
     });

--- a/src/resolvers/updateOne.ts
+++ b/src/resolvers/updateOne.ts
@@ -45,7 +45,7 @@ export function updateOne<TSource = any, TContext = any, TDoc extends Document =
   if (!model || !model.modelName || !model.schema) {
     throw new Error('First arg for Resolver updateOne() should be instance of Mongoose Model.');
   }
-  if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
+  if (!tc || !(tc instanceof ObjectTypeComposer)) {
     throw new Error(
       'Second arg for Resolver updateOne() should be instance of ObjectTypeComposer.'
     );


### PR DESCRIPTION
I've putting some work into getting discriminator support for the composeMongoose function.
Currently my approach is loosely based on the old system, (extending ObjectTypeComposer and building TCs which reflect the mongoose schema more closely) but it is enabled through composeMongooseOpts rather than a different compose function. 
There's also theoretical support for nested discriminator fields with another option, but I'm not as confident in those working, especially on the input types.

```typescript
type ComposeMongooseOpts = {
...
/**
* Support discriminators on base models
*/
includeBaseDiscriminators?: boolean;
/**
* EXPERIMENTAL - Support discriminated fields on nested fields
* May not work as expected on input types for mutations
*/
includeNestedDiscriminators?: boolean;
}
```
### Changes to Existing Code
The following are changes to the current composeMongoose code which are not exclusive to this feature, none of them _should_ be breaking, certainly all existing tests are passing: 

- Using _instanceof_ instead of _constructor.name_ checking ObjectTypeComposer for resolvers in 643bae0c334e01358893253308b40f939bee59ad. 

 - In _src/fieldsConverter.ts_ the options are now passed through any type conversion function which could be a discriminator type (embedded, embedded array, etc.) for supporting nested discriminator behaviour. 
 - In d586798dc80ed0bffc308ababedfe62716d6fcbb I also changed most of the resolvers to use _tc.getTypeName()_ instead of directly passing _tc_ for type, since that points to the correct TC internally, and allows it to be overridden for the EDiscriminatorTypeComposer to point to the InterfaceTC.

## Implementation Overview
The EDiscriminatorTypeComposer class, (E being for Enhanced because DTC is already taken by the old system) which extends the ObjectTypeComposer class, (requiring minimal typing changes in the existing code) contains methods for building and using the discriminator system, and has overrides so field modification works as expected.
```typescript
class EDiscriminatorTypeComposer<TSource, TContext> extends ObjectTypeComposer<TSource, TContext> {
  discriminatorKey: string = '';
  discrimTCs: {
      [key: string]: ... ObjectTypeComposer<any, TContext>;
    } = {};
  BaseTC: ObjectTypeComposer<TSource, TContext>;
  DInputObject: ObjectTypeComposer<TSource, TContext>;
  DInterface: InterfaceTypeComposer<TSource, TContext>;
  opts: ComposeMongooseDiscriminatorsOpts<TContext> = {};
  DKeyETC?: EnumTypeComposer<TContext>;
...
}
```
### Representing the discriminated model/schema:
 - **Output Type:** _DInterface_ is used, which contains resolvers to each of the sub-types inside _discrimTCs_ and the fields from the base (shared) schema. 
 -  **Input Type:** All getter methods for this TC (Including on _DInterface_) should point toward _DInputObject_'s InputTC, which contains an amalgamation* of all of the fields on the _discrimTCs_. 

*(Since GraphQL currently only supports Interface types on outputs, this rudimentary solution should allow all valid input objects to be accepted, with mongoose responsible for validating the exact discriminated type, and is necessary for nested discriminators to be supported for input)

To allow eDTCs to be used throughout the current code with minimal changes, I switched the resolvers in d586798dc80ed0bffc308ababedfe62716d6fcbb to use _tc.getTypeName()_, since I could override it inside the eDTC class to point to _DInterface_ without making any other changes to the resolver logic specific to the eDTC class:
```typescript
getTypeName(): string {
   return this.DInterface.getTypeName();
}
```

### Overriding OTC 'Set' methods
Currently the following 'set' methods (and derivatives) should be supported so they change the correct fields/properties on each component of the eDTC:
 - setField()
 - setExtensions()
 - setDescription()
 - removeField()
 - removeOtherFields()
 - reorderFields()

In addition, I intend to support these methods, but I haven't implemented them yet:
- [ ] makeFieldNonNull()
- [ ] makeFieldNullable()
- [ ] makeFieldPlural()
- [ ] makeFieldNonPlural()
- [ ] deprecate()
- [ ] set/removeResolver()
- [ ] addRelation()
- [ ] set/removeInterface() ? 

There are also a bunch of methods like these which I don't entirely understand the purpose of yet, like those relating to fieldArgs, (are these for input types?) and some which I don't think need a special case for discriminators, but they could be changed on request.

### To Do
 - [ ] Implement currently missing 'set' methods
 - [ ] Enum type on discriminatorKey field for valid types
 - [ ] Examples and tips for documentation
 - [ ] More testing, especially with integration and writing/reading from an actual database using options like filters and sorts etc.
 - [ ] Changes in 643bae0c334e01358893253308b40f939bee59ad need made and PRed into graphql-compose-connection and graphql-compose-pagination repos 

Somewhere along the line I think this addresses #326 since it includes the discriminatorKey field when discriminators are enabled (also currently a custom dKey is required since fields beginning with  '__', importantly here including '__t', are stripped from the field list) 

## Conclusion
While I think this is is decent solution for supporting discriminators with the new composeMongoose function while requiring minimal changes to existing code, I'm still not overly happy with the way it works, several key parts feel much too 'hacky' like overriding getTypeName() and reassigning the InputTC functions. While they work at the minute, I suspect they may be susceptible to breaking from minor changes either in the other code in this plugin, or in graphql-compose.
The input types are also far from ideal, but hopefully this can be revisited when/if graphql introduce input Interface types. As best as I could find this is currently being discussed, and with a spec for it agreed [in their repo](https://github.com/graphql/graphql-spec/blob/main/rfcs/InputUnion.md)
Having said all this, I'm still not really sure what form a better implementation would take, but hopefully this can server to kickstart further discussion on the subject. I've also spent a good amount of time looking at the older implementation of DTCs as part of working on this, so I should be able to answer questions about that.

Finally, this is my first PR, so please point out anything stupid I've done.