### PR TITLE
fix(discriminator): resolved issue with Model type

### DIFF
--- a/src/composeWithMongooseDiscriminators.ts
+++ b/src/composeWithMongooseDiscriminators.ts
@@ -1,10 +1,10 @@
 import { schemaComposer as globalSchemaComposer } from 'graphql-compose';
-import type { Model, Document } from 'mongoose';
+import type { Model } from 'mongoose';
 import { ComposeWithMongooseDiscriminatorsOpts, DiscriminatorTypeComposer } from './discriminators';
 
 export * from './discriminators';
 
-export function composeWithMongooseDiscriminators<TDoc extends Document, TContext = any>(
+export function composeWithMongooseDiscriminators<TDoc, TContext = any>(
   baseModel: Model<TDoc>,
   opts?: ComposeWithMongooseDiscriminatorsOpts<TContext>
 ): DiscriminatorTypeComposer<TDoc, TContext> {


### PR DESCRIPTION
Fixes #366

Stopped document interface from extending mongoose Document.

Based on Mongoose TypeScript [documentation](https://mongoosejs.com/docs/typescript.html) it is advised that document interface not extend `Document`. Using `extends Document` makes it difficult for Mongoose to infer which properties are present on query filters, lean documents, and other cases.

So, without extending `Document` mongoose handles the type casting for models.