### PR TITLE
Export return type of `composeMongoose`

### DIFF
--- a/src/composeMongoose.ts
+++ b/src/composeMongoose.ts
@@ -98,12 +98,17 @@ export type GenerateResolverType<TDoc extends Document, TContext = any> = {
     : any;
 };
 
+export type ObjectTypeComposerWithMongooseResolvers<
+  TDoc extends Document,
+  TContext = any
+> = ObjectTypeComposer<TDoc, TContext> & {
+  mongooseResolvers: GenerateResolverType<TDoc, TContext>;
+};
+
 export function composeMongoose<TDoc extends Document, TContext = any>(
   model: Model<TDoc>,
   opts: ComposeMongooseOpts<TContext> = {}
-): ObjectTypeComposer<TDoc, TContext> & {
-  mongooseResolvers: GenerateResolverType<TDoc, TContext>;
-} {
+): ObjectTypeComposerWithMongooseResolvers<TDoc, TContext> {
   const m: Model<any> = model;
   const name: string = (opts && opts.name) || m.modelName;
 


### PR DESCRIPTION
In my app, I need to use the return type of `composeMongoose`. This PR exports that type for easy access.