### PR TITLE
New feature Request: To allow null, string in Enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "link": "yarn build && yarn link graphql-compose && yarn link graphql-compose-connection && yarn link graphql-compose-pagination && yarn link mongoose && yarn link",
     "unlink": "rimraf node_modules && yarn install",
     "semantic-release": "semantic-release",
-    "test-prev-vers": "yarn add mongoose@5.13.8 @types/mongoose@5.11.97 --dev && yarn lint && git checkout HEAD -- package.json yarn.lock"
+    "test-prev-vers": "yarn add mongoose@5.13.8 --dev --ignore-scripts && yarn coverage && git checkout HEAD -- package.json yarn.lock"
   }
 }

--- a/src/__tests__/fieldConverter-test.ts
+++ b/src/__tests__/fieldConverter-test.ts
@@ -220,6 +220,21 @@ describe('fieldConverter', () => {
       const ocEnum = enumToGraphQL(modelFields.oc, '', schemaComposer);
       expect(ocEnum.getFieldNames()).toEqual(['ocpp1_6', 'ocpp2_0']);
     });
+
+    it('should work with EMPTY_STRING & NULL', () => {
+      const model = mongoose.model(
+        'EnumTestEmpty',
+        new mongoose.Schema({
+          some: {
+            type: String,
+            enum: ['', null, 'val1'],
+          },
+        })
+      );
+      const modelFields = getFieldsFromModel(model);
+      const SomeEnum = enumToGraphQL(modelFields.some, '', schemaComposer);
+      expect(SomeEnum.getFieldNames()).toEqual(['EMPTY_STRING', 'NULL', 'val1']);
+    });
   });
 
   describe('embeddedToGraphQL()', () => {

--- a/src/__tests__/github_issues/384-test.ts
+++ b/src/__tests__/github_issues/384-test.ts
@@ -1,0 +1,116 @@
+import { SchemaComposer, graphql, EnumTypeComposer } from 'graphql-compose';
+import { composeMongoose } from '../../index';
+import { mongoose } from '../../__mocks__/mongooseCommon';
+import { Schema } from 'mongoose';
+
+const schemaComposer = new SchemaComposer<{ req: any }>();
+
+// mongoose.set('debug', true);
+
+const ArticleSchema = new Schema(
+  {
+    name: {
+      type: String,
+      index: true,
+    },
+    label: {
+      type: String,
+      enum: ['', null, 'val1'],
+    },
+  },
+  {
+    collection: 'article',
+  }
+);
+const ArticleModel = mongoose.model<any>('Article', ArticleSchema);
+const ArticleTC = composeMongoose(ArticleModel, { schemaComposer });
+
+let lastResolverInputArg = [] as any;
+const enumTC = ArticleTC.getFieldTC('label') as EnumTypeComposer;
+schemaComposer.Query.addFields({
+  articles: ArticleTC.mongooseResolvers.findMany(),
+  test: {
+    type: enumTC.List,
+    args: { input: enumTC.List },
+    resolve: (_, { input }) => {
+      lastResolverInputArg = [...input];
+      return input;
+    },
+  },
+});
+
+const schema = schemaComposer.buildSchema();
+
+beforeAll(async () => {
+  await ArticleModel.base.createConnection();
+  await ArticleModel.create([
+    { name: 'A1', label: null },
+    { name: 'A2', label: '' },
+    { name: 'A3', label: 'val1' },
+  ]);
+});
+afterAll(() => {
+  ArticleModel.base.disconnect();
+});
+
+describe('issue #384 - New feature Request: To allow null, string in Enum', () => {
+  it('check SDL', async () => {
+    expect(ArticleTC.toSDL({ omitDescriptions: true, deep: true, omitScalars: true }))
+      .toMatchInlineSnapshot(`
+"type Article {
+  name: String
+  label: EnumArticleLabel
+  _id: MongoID!
+}
+
+enum EnumArticleLabel {
+  EMPTY_STRING
+  NULL
+  val1
+}"
+`);
+  });
+
+  it('check runtime output', async () => {
+    const result = await graphql.graphql({
+      schema,
+      contextValue: {},
+      source: `
+        {
+          articles(sort: NAME_ASC) {
+            name
+            label
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: {
+        articles: [
+          { label: null, name: 'A1' }, // <-- special `null` case. It cannot be converted to NULL string
+          { label: 'EMPTY_STRING', name: 'A2' }, // <-- has correct ENUM key
+          { label: 'val1', name: 'A3' },
+        ],
+      },
+    });
+  });
+
+  it('check runtime input', async () => {
+    const result = await graphql.graphql({
+      schema,
+      contextValue: {},
+      source: `
+        {
+          test(input: [val1, NULL, EMPTY_STRING]) 
+        }
+      `,
+    });
+
+    // inside resolvers should be provided real values for null & string
+    expect(lastResolverInputArg).toEqual(['val1', null, '']);
+
+    // in output JSON should be provided keys
+    // BUT be aware `null` does not converted back to `NULL` string
+    expect(result).toEqual({ data: { test: ['val1', null, 'EMPTY_STRING'] } });
+  });
+});

--- a/src/fieldsConverter.ts
+++ b/src/fieldsConverter.ts
@@ -386,13 +386,13 @@ export function enumToGraphQL(
     if (desc) etc.setDescription(desc);
 
     const fields = valueList.reduce((result, value) => {
-      let key
+      let key;
       if (value === null) {
-        key = 'NULL'
+        key = 'NULL';
       } else if (value === '') {
-        key = 'EMPTY_STRING'
+        key = 'EMPTY_STRING';
       } else {
-        key = value.replace(/[^_a-zA-Z0-9]/g, '_').replace(/(^[0-9])(.*)/g, 'a_$1$2')
+        key = value.replace(/[^_a-zA-Z0-9]/g, '_').replace(/(^[0-9])(.*)/g, 'a_$1$2');
       }
       result[key] = { value };
       return result;

--- a/src/fieldsConverter.ts
+++ b/src/fieldsConverter.ts
@@ -386,7 +386,14 @@ export function enumToGraphQL(
     if (desc) etc.setDescription(desc);
 
     const fields = valueList.reduce((result, value) => {
-      const key = value.replace(/[^_a-zA-Z0-9]/g, '_');
+      let key
+      if (value === null) {
+        key = 'NULL'
+      } else if (value === '') {
+        key = 'EMPTY_STRING'
+      } else {
+        key = value.replace(/[^_a-zA-Z0-9]/g, '_').replace(/(^[0-9])(.*)/g, 'a_$1$2')
+      }
       result[key] = { value };
       return result;
     }, {} as Record<string, { value: any }>);


### PR DESCRIPTION
Allow using null and empty String and number as the first char in Enum keys, which make easier for legacy mongoose project to migrate.