### PR TITLE
Fields on _operators are lost on child resolvers when using discriminators

### DIFF
--- a/src/discriminators/__tests__/prepareChildResolvers-test.ts
+++ b/src/discriminators/__tests__/prepareChildResolvers-test.ts
@@ -1,6 +1,7 @@
 import { schemaComposer, ObjectTypeComposer } from 'graphql-compose';
 import { composeWithMongooseDiscriminators } from '../../composeWithMongooseDiscriminators';
 import { getCharacterModels } from '../__mocks__/characterModels';
+import { OPERATORS_FIELDNAME } from '../../resolvers/helpers/filterOperators';
 
 const DKeyFieldName = 'type';
 const { CharacterModel, PersonModel } = getCharacterModels(DKeyFieldName);
@@ -115,6 +116,23 @@ describe('prepareChildResolvers()', () => {
       expect(baseDTC.getResolver('createOne').getArgITC('record').getFieldType('kind')).toEqual(
         PersonTC.getResolver('createOne').getArgITC('record').getFieldType('kind')
       );
+    });
+
+    it('should not copy base _operations to child', () => {
+      expect(
+        baseDTC
+          .getResolver('findMany')
+          .getArgITC('filter')
+          .getField(OPERATORS_FIELDNAME)
+          .type.getTypeName()
+      ).toEqual('FilterFindManyCharacterOperatorsInput');
+
+      expect(
+        PersonTC.getResolver('findMany')
+          .getArgITC('filter')
+          .getField(OPERATORS_FIELDNAME)
+          .type.getTypeName()
+      ).toEqual('FilterFindManyPersonOperatorsInput');
     });
   });
 });

--- a/src/discriminators/prepareChildResolvers.ts
+++ b/src/discriminators/prepareChildResolvers.ts
@@ -4,6 +4,7 @@ import {
   DiscriminatorTypeComposer,
 } from './DiscriminatorTypeComposer';
 import { resolverFactory } from '../resolvers';
+import { OPERATORS_FIELDNAME } from '../resolvers/helpers/filterOperators';
 
 // set the DKey as a query on filter, also project it
 // Also look at it like setting for filters, makes sure to limit
@@ -85,7 +86,10 @@ function copyResolverArgTypes<TSource, TContext>(
         const baseResolverArgTCFields = baseResolverArgTC.getFieldNames();
 
         for (const baseArgField of baseResolverArgTCFields) {
-          if (childResolverArgTC.hasField(baseArgField) && baseArgField !== '_id') {
+          if (
+            childResolverArgTC.hasField(baseArgField) &&
+            ['_id', OPERATORS_FIELDNAME, 'OR', 'AND'].indexOf(baseArgField) === -1
+          ) {
             childResolverArgTC.extendField(baseArgField, {
               type: baseResolverArgTC.getField(baseArgField).type,
             });


### PR DESCRIPTION
As posted on issue #390 

When using discriminators the prepareChildResolver process (copyResolverArgTypes) will treat _operators, AND and OR as fields and call extendField from the baseResolver args to the childResolver args. This will overwrite the contents of these fields removing any specialisation found in the child resolver.