### PR TITLE
Fix issue #415: removeMany should not throw an error if deleteCount equal 0

### DIFF
--- a/src/resolvers/removeMany.ts
+++ b/src/resolvers/removeMany.ts
@@ -94,7 +94,7 @@ export function removeMany<TSource = any, TContext = any, TDoc extends Document 
 
       const res = await beforeQueryHelper(resolveParams);
 
-      if (res.deletedCount) {
+      if (typeof res.deletedCount === 'number') {
         // mongoose v6
         return {
           numAffected: res.deletedCount,


### PR DESCRIPTION
RemoveMany should not throw an error if deleteCount equal 0 to keep same behaviour with mongoose v5 and v6.

Fix issue #415